### PR TITLE
DM-5879 Remove use of Boost smart pointers throughout the Science Pipelines

### DIFF
--- a/include/lsst/ip/isr.h
+++ b/include/lsst/ip/isr.h
@@ -45,7 +45,7 @@
 #include <string>
 #include <vector>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <lsst/afw/math.h>
 #include <lsst/afw/math/Statistics.h>
@@ -206,7 +206,7 @@ namespace isr {
 
     template<typename ImagePixelT, typename FunctionT>
     void fitOverscanImage(
-        boost::shared_ptr<lsst::afw::math::Function1<FunctionT> > &overscanFunction,
+        std::shared_ptr<lsst::afw::math::Function1<FunctionT> > &overscanFunction,
         lsst::afw::image::MaskedImage<ImagePixelT> const& overscan,
         double ssize=1.,
         int sigma=1

--- a/include/lsst/ip/isr.h
+++ b/include/lsst/ip/isr.h
@@ -42,10 +42,9 @@
 #ifndef LSST_IP_ISR_ISR_H
 #define LSST_IP_ISR_ISR_H
 	
+#include <memory>
 #include <string>
 #include <vector>
-
-#include <memory>
 
 #include <lsst/afw/math.h>
 #include <lsst/afw/math/Statistics.h>

--- a/python/lsst/ip/isr/isrLib.i
+++ b/python/lsst/ip/isr/isrLib.i
@@ -37,7 +37,7 @@ Python bindings for lsst::ip::isr Instrument Signature Removal code
 
 // Everything we will need in the _wrap.cc file
 %{
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "lsst/pex/exceptions.h"
 #include "lsst/pex/logging.h"

--- a/src/Isr.cc
+++ b/src/Isr.cc
@@ -77,7 +77,7 @@ size_t maskNans(afw::image::MaskedImage<PixelT> const& mi, afw::image::MaskPixel
 
 template<typename ImagePixelT, typename FunctionT>
 void fitOverscanImage(
-    boost::shared_ptr< afw::math::Function1<FunctionT> > &overscanFunction,
+    std::shared_ptr< afw::math::Function1<FunctionT> > &overscanFunction,
     afw::image::MaskedImage<ImagePixelT> const& overscan,
     double ssize,
     int sigma
@@ -142,14 +142,14 @@ std::string between(std::string &s, char ldelim, char rdelim) {
 
 template
 void fitOverscanImage(
-     boost::shared_ptr<afw::math::Function1<double> > &overscanFunction, 
+     std::shared_ptr<afw::math::Function1<double> > &overscanFunction, 
     afw::image::MaskedImage<float> const& overscan,
     double ssize,
     int sigma);
 
 template
 void fitOverscanImage(
-     boost::shared_ptr<afw::math::Function1<double> > &overscanFunction,
+     std::shared_ptr<afw::math::Function1<double> > &overscanFunction,
     afw::image::MaskedImage<double> const& overscan,
     double ssize,
     int sigma);


### PR DESCRIPTION
Makes the following replacements:

- boost::scoped_ptr -> std::unique_ptr
- boost::shared_ptr -> std::shared_ptr
- boost::weak_ptr -> std::weak_ptr
- boost::static_pointer_cast -> std::static_pointer_cast
- boost::dynamic_pointer_cast -> std::dynamic_pointer_cast
- boost::const_pointer_cast -> std::const_pointer_cast
- boost::reinterpret_pointer_cast -> std::reinterpret_pointer_cast
- boost::enamble_shared_from_this -> std::enable_shared_from_this
- boost pointer related includes -> standard library memory
