### PR TITLE
Update for exposure time and date not in Calib

### DIFF
--- a/examples/exampleUtils.py
+++ b/examples/exampleUtils.py
@@ -263,8 +263,8 @@ def makeRaw(darkval, oscan, gradient, exptime):
     '''
     rawExposure = makeAssemblyInput(False)
     detector = rawExposure.getDetector()
-    calib = rawExposure.getCalib()
-    calib.setExptime(exptime)
+    visitInfo = afwImage.makeVisitInfo(exposureTime=exptime)
+    rawExposure.getInfo().setVisitInfo(visitInfo)
     im = rawExposure.getMaskedImage().getImage()
     for amp in detector:
         subim = im.Factory(im, amp.getRawDataBBox())
@@ -289,8 +289,8 @@ def makeDark(darkval, exptime):
     '''
     darkExposure = makeAssemblyInput(False, doTrim=True)
     detector = darkExposure.getDetector()
-    calib = darkExposure.getCalib()
-    calib.setExptime(exptime)
+    visitInfo = afwImage.makeVisitInfo(exposureTime=exptime)
+    darkExposure.getInfo().setVisitInfo(visitInfo)
     im = darkExposure.getMaskedImage().getImage()
     for amp in detector:
         subim = im.Factory(im, amp.getBBox())

--- a/python/lsst/ip/isr/assembleCcdTask.py
+++ b/python/lsst/ip/isr/assembleCcdTask.py
@@ -255,12 +255,9 @@ class AssembleCcdTask(pipeBase.Task):
         if self.config.setGain:
             self.setGain(outExposure=outExposure)
 
-        inCalib = inExposure.getCalib()
-        outCalib = outExposure.getCalib()
-        outCalib.setExptime(inCalib.getExptime())
-        outCalib.setMidTime(inCalib.getMidTime())
-
+        # note: Calib is not copied, presumably because it is assumed unknown in raw data
         outExposure.setFilter(inExposure.getFilter())
+        outExposure.getInfo().setVisitInfo(inExposure.getInfo().getVisitInfo())
 
         frame = getDebugFrame(self._display, "assembledExposure")
         if frame:

--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -528,7 +528,8 @@ class IsrTask(pipeBase.CmdLineTask):
         if self.config.doFringe and self.config.fringeAfterFlat:
             self.fringe.run(ccdExposure, **fringes.getDict())
 
-        ccdExposure.getCalib().setFluxMag0(self.config.fluxMag0T1 * ccdExposure.getCalib().getExptime())
+        exposureTime = ccdExposure.getInfo().getVisitInfo().getExposureTime()
+        ccdExposure.getCalib().setFluxMag0(self.config.fluxMag0T1*exposureTime)
 
         frame = getDebugFrame(self._display, "postISRCCD")
         if frame:
@@ -593,12 +594,11 @@ class IsrTask(pipeBase.CmdLineTask):
         \param[in,out]  exposure        exposure to process
         \param[in]      darkExposure    dark exposure of same size as exposure
         """
-        darkCalib = darkExposure.getCalib()
         isr.darkCorrection(
             maskedImage=exposure.getMaskedImage(),
             darkMaskedImage=darkExposure.getMaskedImage(),
-            expScale=exposure.getCalib().getExptime(),
-            darkScale=darkCalib.getExptime(),
+            expScale=exposure.getInfo().getVisitInfo().getExposureTime(),
+            darkScale=darkExposure.getInfo().getVisitInfo().getExposureTime(),
         )
 
     def doLinearize(self, detector):


### PR DESCRIPTION
Update all code that used exposure time or date in Calib,
switching to VisitInfo instead.