### PR TITLE
DM-11776: suppress numpy NAN warnings

### DIFF
--- a/python/lsst/ip/isr/isrFunctions.py
+++ b/python/lsst/ip/isr/isrFunctions.py
@@ -377,13 +377,14 @@ def overscanCorrection(ampMaskedImage, overscanImage, fitType='MEDIAN', order=1,
                                                   weights=1-collapsedMask.astype(int))
             # Binning is just a histogram, with weights equal to the values.
             # Use a similar trick to get the bin centers (this deals with different numbers per bin).
-            values = numpy.histogram(indices, bins=numBins,
-                                     weights=collapsed.data*~collapsedMask)[0]/numPerBin
-            binCenters = numpy.histogram(indices, bins=numBins,
-                                         weights=indices*~collapsedMask)[0]/numPerBin
-            interp = afwMath.makeInterpolate(binCenters.astype(float)[numPerBin > 0],
-                                             values.astype(float)[numPerBin > 0],
-                                             afwMath.stringToInterpStyle(fitType))
+            with numpy.errstate(invalid="ignore"):  # suppress NAN warnings
+                values = numpy.histogram(indices, bins=numBins,
+                                         weights=collapsed.data*~collapsedMask)[0]/numPerBin
+                binCenters = numpy.histogram(indices, bins=numBins,
+                                             weights=indices*~collapsedMask)[0]/numPerBin
+                interp = afwMath.makeInterpolate(binCenters.astype(float)[numPerBin > 0],
+                                                 values.astype(float)[numPerBin > 0],
+                                                 afwMath.stringToInterpStyle(fitType))
             fitBiasArr = numpy.array([interp.interpolate(i) for i in indices])
 
         import lsstDebug

--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -933,21 +933,22 @@ class IsrTask(pipeBase.CmdLineTask):
                 tmpArray = tempImage.getArray()
                 outArray = outImage.getArray()
 
-                # First derivative term
-                gradTmp = numpy.gradient(tmpArray[startY:endY, startX:endX])
-                gradOut = numpy.gradient(outArray[startY:endY, startX:endX])
-                first = (gradTmp[0]*gradOut[0] + gradTmp[1]*gradOut[1])[1:-1, 1:-1]
+                with numpy.errstate(invalid="ignore", over="ignore"):
+                    # First derivative term
+                    gradTmp = numpy.gradient(tmpArray[startY:endY, startX:endX])
+                    gradOut = numpy.gradient(outArray[startY:endY, startX:endX])
+                    first = (gradTmp[0]*gradOut[0] + gradTmp[1]*gradOut[1])[1:-1, 1:-1]
 
-                # Second derivative term
-                diffOut20 = numpy.diff(outArray, 2, 0)[startY:endY, startX + 1:endX - 1]
-                diffOut21 = numpy.diff(outArray, 2, 1)[startY + 1:endY - 1, startX:endX]
-                second = tmpArray[startY + 1:endY - 1, startX + 1:endX - 1]*(diffOut20 + diffOut21)
+                    # Second derivative term
+                    diffOut20 = numpy.diff(outArray, 2, 0)[startY:endY, startX + 1:endX - 1]
+                    diffOut21 = numpy.diff(outArray, 2, 1)[startY + 1:endY - 1, startX:endX]
+                    second = tmpArray[startY + 1:endY - 1, startX + 1:endX - 1]*(diffOut20 + diffOut21)
 
-                corr[startY + 1:endY - 1, startX + 1:endX - 1] = 0.5*(first + second)
+                    corr[startY + 1:endY - 1, startX + 1:endX - 1] = 0.5*(first + second)
 
-                tmpArray[:, :] = image.getArray()[:, :]
-                tmpArray[nanIndex] = 0.
-                tmpArray[startY:endY, startX:endX] += corr[startY:endY, startX:endX]
+                    tmpArray[:, :] = image.getArray()[:, :]
+                    tmpArray[nanIndex] = 0.
+                    tmpArray[startY:endY, startX:endX] += corr[startY:endY, startX:endX]
 
                 if iteration > 0:
                     diff = numpy.sum(numpy.abs(prev_image - tmpArray))


### PR DESCRIPTION
We don't care, and they clutter the output.