### PR TITLE
DM-2639: {{Standardize primary method names, run/runDataRef, across PipeTasks}}

### DIFF
--- a/python/lsst/ip/isr/measureCrosstalk.py
+++ b/python/lsst/ip/isr/measureCrosstalk.py
@@ -195,7 +195,7 @@ class MeasureCrosstalkTask(CmdLineTask):
             pickle.dump(resultList, open(results.parsedCmd.dumpRatios, "w"))
         return task.reduce(resultList)
 
-    def run(self, dataRef):
+    def runDataRef(self, dataRef):
         """Get crosstalk ratios for CCD
 
         Parameters

--- a/tests/test_crosstalk.py
+++ b/tests/test_crosstalk.py
@@ -188,7 +188,7 @@ class CrosstalkTestCase(lsst.utils.tests.TestCase):
         config.threshold = self.value - 1
         measure = MeasureCrosstalkTask(config=config)
         fakeDataRef = Struct(dataId={'fake': 1})
-        coeff, coeffErr, coeffNum = measure.reduce([measure.run(fakeDataRef)])
+        coeff, coeffErr, coeffNum = measure.reduce([measure.runDataRef(fakeDataRef)])
         self.checkCoefficients(coeff, coeffErr, coeffNum)
 
         config = IsrTask.ConfigClass()


### PR DESCRIPTION
Rename methods according to RFC-352.
Fifteen total repositories with changes.
