### PR TITLE
Convert isrTask to valid pipelineTask.

### DIFF
--- a/python/lsst/ip/isr/linearize.py
+++ b/python/lsst/ip/isr/linearize.py
@@ -29,6 +29,26 @@ from .applyLookupTable import applyLookupTable
 __all__ = ["LinearizeBase", "LinearizeLookupTable", "LinearizeSquared"]
 
 
+def getLinearityTypeByName(linearityTypeName):
+    """Determine the linearity class to use if the type is known.
+
+    Parameters
+    ----------
+    linearityTypeName : str
+        String name of the linearity type that is needed.
+
+    Returns
+    -------
+    linearityType : `~lsst.ip.isr.linearize.LinearizeSquared`
+        The appropriate linearity class to use.  If no matching class
+        is found, `None` is returned.
+    """
+    for t in [LinearizeLookupTable, LinearizeSquared]:
+        if t.LinearityType == linearityTypeName:
+            return t
+    return None
+
+
 class LinearizeBase(metaclass=abc.ABCMeta):
     """Abstract base class functor for correcting non-linearity
 

--- a/tests/test_addDistortionModel.py
+++ b/tests/test_addDistortionModel.py
@@ -86,7 +86,7 @@ class ApplyLookupTableTestCase(lsst.utils.tests.TestCase):
         """Test IsrTask.run with config.doAddDistortionModel true"""
         isrConfig = self.makeMinimalIsrConfig()
         isrConfig.doAddDistortionModel = True
-        isrTask = IsrTask(isrConfig)
+        isrTask = IsrTask(config=isrConfig)
         with self.assertRaises(RuntimeError):
             # the camera argument is required
             isrTask.run(ccdExposure=self.exposure)
@@ -97,7 +97,7 @@ class ApplyLookupTableTestCase(lsst.utils.tests.TestCase):
     def testRunWithoutAddDistortionModel(self):
         """Test IsrTask.run with config.doAddDistortionModel false"""
         isrConfig = self.makeMinimalIsrConfig()
-        isrTask = IsrTask(isrConfig)
+        isrTask = IsrTask(config=isrConfig)
 
         # the camera argument is not needed
         exposure = isrTask.run(ccdExposure=self.exposure).exposure


### PR DESCRIPTION
Additional configuration options now exist to define the required
input/output dataset types, and appropriate handlers correctly remove
these datasets if the isr configuration will not require (for inputs)
or generate (for outputs) those products.  As the camera configuration
is not currently fully populated, the obs_subaru/hsc configuration is
read to set the correct parameters.