### PR TITLE
DM-15683: Add tests for ip_isr/isrTask

### DIFF
--- a/bin.src/runIsr.py
+++ b/bin.src/runIsr.py
@@ -21,6 +21,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+
 from lsst.ip.isr.isrTask import RunIsrTask
 
 RunIsrTask.parseAndRun()

--- a/python/lsst/ip/isr/crosstalk.py
+++ b/python/lsst/ip/isr/crosstalk.py
@@ -29,7 +29,8 @@ import lsst.afw.detection
 from lsst.pex.config import Config, Field, ChoiceField
 from lsst.pipe.base import Task
 
-__all__ = ["CrosstalkConfig", "CrosstalkTask", "subtractCrosstalk", "writeCrosstalkCoeffs"]
+__all__ = ["CrosstalkConfig", "CrosstalkTask", "subtractCrosstalk", "writeCrosstalkCoeffs",
+           "NullCrosstalkTask"]
 
 
 class CrosstalkConfig(Config):
@@ -59,6 +60,7 @@ class CrosstalkConfig(Config):
 class CrosstalkTask(Task):
     """Apply intra-CCD crosstalk correction"""
     ConfigClass = CrosstalkConfig
+    _DefaultName = 'isrCrosstalk'
 
     def prepCrosstalk(self, dataRef):
         """Placeholder for crosstalk preparation method, e.g., for inter-CCD crosstalk.

--- a/python/lsst/ip/isr/fringe.py
+++ b/python/lsst/ip/isr/fringe.py
@@ -71,6 +71,7 @@ class FringeTask(Task):
     and solve for the scales simultaneously.
     """
     ConfigClass = FringeConfig
+    _DefaultName = 'isrFringe'
 
     def readFringes(self, dataRef, assembler=None):
         """Read the fringe frame(s)

--- a/python/lsst/ip/isr/isrFunctions.py
+++ b/python/lsst/ip/isr/isrFunctions.py
@@ -428,9 +428,7 @@ def flatCorrection(maskedImage, flatMaskedImage, scalingType, userScale=1.0, inv
     ------
     RuntimeError
         Raised if ``maskedImage`` and ``flatMaskedImage`` do not have
-        the same size.
-    pexExcept.Exception
-        Raised if ``scalingType`` is not an allowed value.
+        the same size or if ``scalingType`` is not an allowed value.
     """
     if trimToFit:
         maskedImage = trimToMatchCalibBBox(maskedImage, flatMaskedImage)
@@ -448,7 +446,7 @@ def flatCorrection(maskedImage, flatMaskedImage, scalingType, userScale=1.0, inv
     elif scalingType == 'USER':
         flatScale = userScale
     else:
-        raise pexExcept.Exception('%s : %s not implemented' % ("flatCorrection", scalingType))
+        raise RuntimeError('%s : %s not implemented' % ("flatCorrection", scalingType))
 
     if not invert:
         maskedImage.scaledDivides(1.0/flatScale, flatMaskedImage)

--- a/python/lsst/ip/isr/isrMock.py
+++ b/python/lsst/ip/isr/isrMock.py
@@ -330,11 +330,8 @@ class IsrMock(pipeBase.Task):
         defectList : `lsst.meas.algorithms.Defects`
             Simulated defect list
         """
-        defectList = []
-        box = lsst.geom.Box2I(lsst.geom.Point2I(0, 0),
-                              lsst.geom.Extent2I(40, 50))
-        defectList.append(box)
-        return Defects(defectList)
+        return Defects([lsst.geom.Box2I(lsst.geom.Point2I(0, 0),
+                                        lsst.geom.Extent2I(40, 50))])
 
     def makeCrosstalkCoeff(self):
         """Generate the simulated crosstalk coefficients.

--- a/python/lsst/ip/isr/isrMock.py
+++ b/python/lsst/ip/isr/isrMock.py
@@ -40,7 +40,7 @@ __all__ = ["IsrMockConfig", "IsrMock", "RawMock", "TrimmedRawMock", "RawDictMock
 
 
 class IsrMockConfig(pexConfig.Config):
-    r"""Configuration parameters for isrMock.
+    """Configuration parameters for isrMock.
 
     These parameters produce generic fixed position signals from
     various sources, and combine them in a way that matches how those
@@ -229,7 +229,7 @@ class IsrMockConfig(pexConfig.Config):
 
 
 class IsrMock(pipeBase.Task):
-    r"""Class to generate consistent mock images for ISR testing.
+    """Class to generate consistent mock images for ISR testing.
 
     ISR testing currently relies on one-off fake images that do not
     accurately mimic the full set of detector effects. This class
@@ -259,7 +259,7 @@ class IsrMock(pipeBase.Task):
                                   [1., 4., 7., 4., 1.]]) / 273.0
 
     def run(self):
-        r"""Generate a mock ISR product, and return it.
+        """Generate a mock ISR product, and return it.
 
         Returns
         -------
@@ -285,7 +285,7 @@ class IsrMock(pipeBase.Task):
             return None
 
     def makeData(self):
-        r"""Generate simulated ISR data.
+        """Generate simulated ISR data.
 
         Currently, only the class defined crosstalk coefficient
         matrix, brighter-fatter kernel, a constant unity transmission
@@ -313,7 +313,7 @@ class IsrMock(pipeBase.Task):
             return None
 
     def makeBfKernel(self):
-        r"""Generate a simple Gaussian brighter-fatter kernel.
+        """Generate a simple Gaussian brighter-fatter kernel.
 
         Returns
         -------
@@ -323,7 +323,7 @@ class IsrMock(pipeBase.Task):
         return self.bfKernel
 
     def makeDefectList(self):
-        r"""Generate a simple single-entry defect list.
+        """Generate a simple single-entry defect list.
 
         Returns
         -------
@@ -334,7 +334,7 @@ class IsrMock(pipeBase.Task):
                                        lsst.geom.Extent2I(40, 50)))
 
     def makeCrosstalkCoeff(self):
-        r"""Generate the simulated crosstalk coefficients.
+        """Generate the simulated crosstalk coefficients.
 
         Returns
         -------
@@ -345,7 +345,7 @@ class IsrMock(pipeBase.Task):
         return self.crosstalkCoeffs
 
     def makeTransmissionCurve(self):
-        r"""Generate a simulated flat transmission curve.
+        """Generate a simulated flat transmission curve.
 
         Returns
         -------
@@ -356,7 +356,7 @@ class IsrMock(pipeBase.Task):
         return afwImage.TransmissionCurve.makeIdentity()
 
     def makeImage(self):
-        r"""Generate a simulated ISR image.
+        """Generate a simulated ISR image.
 
         Returns
         -------
@@ -474,7 +474,7 @@ class IsrMock(pipeBase.Task):
 
     # afw primatives to construct the image structure
     def getCamera(self):
-        r"""Construct a test camera object.
+        """Construct a test camera object.
 
         Returns
         -------
@@ -486,7 +486,7 @@ class IsrMock(pipeBase.Task):
         return camera
 
     def getExposure(self):
-        r"""Construct a test exposure.
+        """Construct a test exposure.
 
         The test exposure has a simple WCS set, as well as a list of
         unlikely header keywords that can be removed during ISR
@@ -536,7 +536,7 @@ class IsrMock(pipeBase.Task):
         return exposure
 
     def getWcs(self):
-        r"""Construct a dummy WCS object.
+        """Construct a dummy WCS object.
 
         Taken from the deprecated ip_isr/examples/exampleUtils.py.
 
@@ -553,7 +553,7 @@ class IsrMock(pipeBase.Task):
                                   cdMatrix=afwGeom.makeCdMatrix(scale=1.0*lsst.geom.degrees))
 
     def localCoordToExpCoord(self, ampData, x, y):
-        r"""Convert between a local amplifier coordinate and the full
+        """Convert between a local amplifier coordinate and the full
         exposure coordinate.
 
         Parameters
@@ -584,7 +584,7 @@ class IsrMock(pipeBase.Task):
 
     # Simple data values.
     def amplifierAddNoise(self, ampData, mean, sigma):
-        r"""Add Gaussian noise to an amplifier's image data.
+        """Add Gaussian noise to an amplifier's image data.
 
          This method operates in the amplifier coordinate frame.
 
@@ -602,7 +602,7 @@ class IsrMock(pipeBase.Task):
                                                 size=ampData.getDimensions()).transpose()
 
     def amplifierAddYGradient(self, ampData, start, end):
-        r"""Add a y-axis linear gradient to an amplifier's image data.
+        """Add a y-axis linear gradient to an amplifier's image data.
 
          This method operates in the amplifier coordinate frame.
 
@@ -621,7 +621,7 @@ class IsrMock(pipeBase.Task):
                                  np.zeros(ampData.getDimensions()).transpose())
 
     def amplifierAddSource(self, ampData, scale, x0, y0):
-        r"""Add a single Gaussian source to an amplifier.
+        """Add a single Gaussian source to an amplifier.
 
          This method operates in the amplifier coordinate frame.
 
@@ -642,7 +642,7 @@ class IsrMock(pipeBase.Task):
                                        scale * np.exp(-0.5 * ((x - x0)**2 + (y - y0)**2) / 3.0**2))
 
     def amplifierAddCT(self, ampDataSource, ampDataTarget, scale):
-        r"""Add a scaled copy of an amplifier to another, simulating crosstalk.
+        """Add a scaled copy of an amplifier to another, simulating crosstalk.
 
          This method operates in the amplifier coordinate frame.
 
@@ -664,7 +664,7 @@ class IsrMock(pipeBase.Task):
 
     # Functional form data values
     def amplifierAddFringe(self, amp, ampData, scale):
-        r"""Add a fringe-like ripple pattern to an amplifier's image data.
+        """Add a fringe-like ripple pattern to an amplifier's image data.
 
         Parameters
         ----------
@@ -690,7 +690,7 @@ class IsrMock(pipeBase.Task):
                                        scale * np.sinc(((u - 100)/150)**2 + (v / 150)**2))
 
     def amplifierMultiplyFlat(self, amp, ampData, fracDrop, u0=100.0, v0=100.0):
-        r"""Multiply an amplifier's image data by a flat-like pattern.
+        """Multiply an amplifier's image data by a flat-like pattern.
 
         Parameters
         ----------
@@ -725,7 +725,7 @@ class IsrMock(pipeBase.Task):
 
 
 class RawMock(IsrMock):
-    r"""Generate a raw exposure suitable for ISR.
+    """Generate a raw exposure suitable for ISR.
     """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -741,7 +741,7 @@ class RawMock(IsrMock):
 
 
 class TrimmedRawMock(RawMock):
-    r"""Generate a trimmed raw exposure.
+    """Generate a trimmed raw exposure.
     """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -750,7 +750,7 @@ class TrimmedRawMock(RawMock):
 
 
 class CalibratedRawMock(RawMock):
-    r"""Generate a trimmed raw exposure.
+    """Generate a trimmed raw exposure.
     """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -766,7 +766,7 @@ class CalibratedRawMock(RawMock):
 
 
 class RawDictMock(RawMock):
-    r"""Generate a raw exposure dict suitable for ISR.
+    """Generate a raw exposure dict suitable for ISR.
     """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -774,7 +774,7 @@ class RawDictMock(RawMock):
 
 
 class MasterMock(IsrMock):
-    r"""Parent class for those that make master calibrations.
+    """Parent class for those that make master calibrations.
     """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -792,7 +792,7 @@ class MasterMock(IsrMock):
 
 
 class BiasMock(MasterMock):
-    r"""Simulated master bias calibration.
+    """Simulated master bias calibration.
     """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -801,7 +801,7 @@ class BiasMock(MasterMock):
 
 
 class DarkMock(MasterMock):
-    r"""Simulated master dark calibration.
+    """Simulated master dark calibration.
     """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -810,7 +810,7 @@ class DarkMock(MasterMock):
 
 
 class FlatMock(MasterMock):
-    r"""Simulated master flat calibration.
+    """Simulated master flat calibration.
     """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -818,7 +818,7 @@ class FlatMock(MasterMock):
 
 
 class FringeMock(MasterMock):
-    r"""Simulated master fringe calibration.
+    """Simulated master fringe calibration.
     """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -826,7 +826,7 @@ class FringeMock(MasterMock):
 
 
 class UntrimmedFringeMock(FringeMock):
-    r"""Simulated untrimmed master fringe calibration.
+    """Simulated untrimmed master fringe calibration.
     """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -834,7 +834,7 @@ class UntrimmedFringeMock(FringeMock):
 
 
 class BfKernelMock(IsrMock):
-    r"""Simulated brighter-fatter kernel.
+    """Simulated brighter-fatter kernel.
     """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -847,7 +847,7 @@ class BfKernelMock(IsrMock):
 
 
 class DefectMock(IsrMock):
-    r"""Simulated defect list.
+    """Simulated defect list.
     """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -860,7 +860,7 @@ class DefectMock(IsrMock):
 
 
 class CrosstalkCoeffMock(IsrMock):
-    r"""Simulated crosstalk coefficient matrix.
+    """Simulated crosstalk coefficient matrix.
     """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -873,7 +873,7 @@ class CrosstalkCoeffMock(IsrMock):
 
 
 class TransmissionMock(IsrMock):
-    r"""Simulated transmission curve.
+    """Simulated transmission curve.
     """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -886,7 +886,7 @@ class TransmissionMock(IsrMock):
 
 
 class DataRefMock(object):
-    r"""Simulated gen2 butler data ref.
+    """Simulated gen2 butler data ref.
 
     Currently only supports get and put operations, which are most
     likely to be called for data in ISR processing.
@@ -918,7 +918,7 @@ class DataRefMock(object):
         self.config.doGenerateData = True
 
     def get(self, dataType, **kwargs):
-        r"""Return an appropriate data product.
+        """Return an appropriate data product.
 
         Parameters
         ----------
@@ -971,7 +971,7 @@ class DataRefMock(object):
             raise RuntimeError("ISR DataRefMock cannot return %s.", dataType)
 
     def put(self, exposure, filename):
-        r"""Write an exposure to a FITS file.
+        """Write an exposure to a FITS file.
 
         Parameters
         ----------

--- a/python/lsst/ip/isr/isrMock.py
+++ b/python/lsst/ip/isr/isrMock.py
@@ -330,8 +330,11 @@ class IsrMock(pipeBase.Task):
         defectList : `lsst.meas.algorithms.Defects`
             Simulated defect list
         """
-        return Defects(lsst.geom.Box2I(lsst.geom.Point2I(0, 0),
-                                       lsst.geom.Extent2I(40, 50)))
+        defectList = []
+        box = lsst.geom.Box2I(lsst.geom.Point2I(0, 0),
+                              lsst.geom.Extent2I(40, 50))
+        defectList.append(box)
+        return Defects(defectList)
 
     def makeCrosstalkCoeff(self):
         """Generate the simulated crosstalk coefficients.

--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -667,7 +667,7 @@ class IsrTaskConfig(pexConfig.Config):
 
 
 class IsrTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
-    r"""Apply common instrument signature correction algorithms to a raw frame.
+    """Apply common instrument signature correction algorithms to a raw frame.
 
     The process for correcting imaging data is very similar from
     camera to camera.  This task provides a vanilla implementation of
@@ -1464,6 +1464,9 @@ class IsrTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
             inputExp = afwImage.makeExposure(inputExp)
         elif isinstance(inputExp, afwImage.Exposure):
             pass
+        elif inputExp is None:
+            # Assume this will be caught by the setup if it is a problem.
+            return inputExp
         else:
             raise TypeError(f"Input Exposure is not known type in isrTask.ensureExposure: {type(inputExp)}")
 
@@ -1555,6 +1558,8 @@ class IsrTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
             limits.update({self.config.saturatedMaskName: amp.getSaturation()})
         if self.config.doSuspect and not badAmp:
             limits.update({self.config.suspectMaskName: amp.getSuspectLevel()})
+        if math.isfinite(self.config.saturation):
+            limits.update({self.config.saturatedMaskName: self.config.saturation})
 
         for maskName, maskThreshold in limits.items():
             if not math.isnan(maskThreshold):

--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -1140,7 +1140,8 @@ class IsrTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
                                        (amp.getName(), qaMedian, qaStdev))
                         ccdExposure.getMetadata().set('OVERSCAN', "Overscan corrected")
                 else:
-                    self.log.warn("Amplifier %s is bad." % (amp.getName()))
+                    if badAmp:
+                        self.log.warn("Amplifier %s is bad." % (amp.getName()))
                     overscanResults = None
 
                 overscans.append(overscanResults if overscanResults is not None else None)
@@ -2216,7 +2217,6 @@ class FakeAmp(object):
 
     def getSuspectLevel(self):
         return float("NaN")
-
 
 
 class RunIsrConfig(pexConfig.Config):

--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -2213,6 +2213,7 @@ class FakeAmp(object):
         return float("NaN")
 
 
+
 class RunIsrConfig(pexConfig.Config):
     isr = pexConfig.ConfigurableField(target=IsrTask, doc="Instrument signature removal")
 

--- a/python/lsst/ip/isr/straylight.py
+++ b/python/lsst/ip/isr/straylight.py
@@ -38,6 +38,7 @@ class StrayLightTask(Task):
     This is a dummy task to be retargeted with an camera-specific version.
     """
     ConfigClass = StrayLightConfig
+    _DefaultName = "isrStrayLight"
 
     def readIsrData(self, dataRef, rawExposure):
         """Read and return calibration products relevant for correcting

--- a/tests/test_assembleCcd.py
+++ b/tests/test_assembleCcd.py
@@ -1,0 +1,91 @@
+#
+# LSST Data Management System
+# Copyright 2008-2017 AURA/LSST.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+
+import unittest
+
+import lsst.utils.tests
+from lsst.ip.isr.assembleCcdTask import (AssembleCcdConfig, AssembleCcdTask)
+import lsst.ip.isr.isrMock as isrMock
+
+
+class AssembleCcdTestCases(lsst.utils.tests.TestCase):
+
+    def setUp(self):
+        self.outputExp = isrMock.TrimmedRawMock().run()
+        self.outputUntrimmedExp = isrMock.RawMock().run()
+
+    def runTest(self, inputExp=None, doTrim=False):
+        """Test guts to avoid code duplication.
+
+        Parameters
+        ----------
+        inputExp : `lsst.afw.image.Exposure`
+            Exposure to assemble.
+        doTrim : `bool`
+            To trim the input or not to trim.
+
+        Returns
+        -------
+        assembleOutput : `lsst.afw.image.Exposure`
+            Assembled exposure.
+
+        Raises
+        ------
+        TypeError
+            Raised if the inputExp is None.
+        """
+        self.config = AssembleCcdConfig(doTrim=doTrim,
+                                        keysToRemove=['SHEEP', 'MONKEYS', 'ZSHEEP'])
+        self.task = AssembleCcdTask(config=self.config)
+
+        return self.task.assembleCcd(inputExp)
+
+    def testAssembleCcdTask_exp_noTrim(self):
+        self.assertEqual(self.runTest(inputExp=isrMock.RawMock().run(), doTrim=False).getBBox(),
+                         self.outputUntrimmedExp.getBBox())
+
+    def testAssembleCcdTask_exp_doTrim(self):
+        self.assertEqual(self.runTest(inputExp=isrMock.RawMock().run(), doTrim=True).getBBox(),
+                         self.outputExp.getBBox())
+
+    def testAssembleCcdTask_expDict_noTrim(self):
+        self.assertEqual(self.runTest(inputExp=isrMock.RawDictMock().run(), doTrim=False).getBBox(),
+                         self.outputUntrimmedExp.getBBox())
+
+    def testAssembleCcdTask_expDict_doTrim(self):
+        self.assertEqual(self.runTest(inputExp=isrMock.RawDictMock().run(), doTrim=True).getBBox(),
+                         self.outputExp.getBBox())
+
+    def testAssembleCcdTask_fail(self):
+        """Assembly should fail if no exposure is supplied.
+        """
+        with self.assertRaises(TypeError):
+            self.runTest(inputExp=None, doTrim=False)
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_assembleCcd.py
+++ b/tests/test_assembleCcd.py
@@ -34,7 +34,8 @@ class AssembleCcdTestCases(lsst.utils.tests.TestCase):
         self.outputUntrimmedExp = isrMock.RawMock().run()
 
     def runTest(self, inputExp=None, doTrim=False):
-        """Test guts to avoid code duplication.
+        """Create an appropriate assembly configuration and task, returning
+        the results of AssembleCcdTask.assembleCcd().
 
         Parameters
         ----------

--- a/tests/test_brighterFatter.py
+++ b/tests/test_brighterFatter.py
@@ -26,7 +26,6 @@ import os
 
 import lsst.utils.tests
 import lsst.afw.image as afwImage
-# import lsst.ip.isr as ipIsr
 import lsst.ip.isr.isrFunctions as isrFunctions
 
 
@@ -54,7 +53,6 @@ class BrighterFatterTestCases(lsst.utils.tests.TestCase):
         mi = afwImage.makeMaskedImage(image)
         exp = afwImage.makeExposure(mi)
 
-#        isrTask = ipIsr.IsrTask()
         with open(self.filename, 'rb') as f:
             bfKernel = pickle.load(f)
 

--- a/tests/test_fringes.py
+++ b/tests/test_fringes.py
@@ -27,7 +27,10 @@ import lsst.utils.tests
 import lsst.afw.math as afwMath
 import lsst.afw.image as afwImage
 import lsst.afw.image.utils as afwImageUtils
+import lsst.pipe.base as pipeBase
 from lsst.ip.isr.fringe import FringeTask
+
+import lsst.ip.isr.isrMock as isrMock
 
 try:
     display
@@ -90,6 +93,7 @@ class FringeTestCase(lsst.utils.tests.TestCase):
         self.config.small = 1
         self.config.large = 128
         self.config.pedestal = False
+        self.config.iterations = 10
         afwImageUtils.defineFilter('FILTER', lambdaEff=0)
 
     def tearDown(self):
@@ -251,6 +255,15 @@ class FringeTestCase(lsst.utils.tests.TestCase):
         mi = exp.getMaskedImage()
         mi -= afwMath.makeStatistics(mi, afwMath.MEAN).getValue()
         self.assertLess(afwMath.makeStatistics(mi, afwMath.STDEV).getValue(), stddevMax)
+
+    def test_readFringes(self):
+        """Test that fringes can be successfully accessed from the butler.
+        """
+        task = FringeTask()
+        dataRef = isrMock.DataRefMock()
+
+        result = task.readFringes(dataRef, assembler=None)
+        self.assertIsInstance(result, pipeBase.Struct)
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_isrFunctions.py
+++ b/tests/test_isrFunctions.py
@@ -1,0 +1,416 @@
+#
+# LSST Data Management System
+# Copyright 2008-2017 AURA/LSST.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+
+import unittest
+import numpy as np
+
+import lsst.afw.image as afwImage
+import lsst.utils.tests
+import lsst.ip.isr as ipIsr
+import lsst.pex.exceptions as pexExcept
+import lsst.ip.isr.isrMock as isrMock
+import lsst.pipe.base as pipeBase
+
+
+def countMaskedPixels(maskedImage, maskPlane):
+    """Function to count the number of masked pixels of a given type.
+
+    Parameters
+    ----------
+    maskedImage : `lsst.afw.image.MaskedImage`
+        Image to measure the mask on.
+    maskPlane : `str`
+        Name of the mask plane to count
+
+    Returns
+    -------
+    nMask : `int`
+        Number of masked pixels.
+    """
+    bitMask = maskedImage.getMask().getPlaneBitMask(maskPlane)
+    isBit = maskedImage.getMask().getArray() & bitMask > 0
+    numBit = np.sum(isBit)
+
+    return numBit
+
+
+def computeImageMedianAndStd(image):
+    """Function to calculate median and std of image data.
+
+    Parameters
+    ----------
+    image : `lsst.afw.image.Image`
+        Image to measure statistics on.
+
+    Returns
+    -------
+    median : `float`
+        Image median.
+    std : `float`
+        Image stddev.
+    """
+    median = np.nanmedian(image.getArray())
+    std = np.nanstd(image.getArray())
+
+    return (median, std)
+
+
+class IsrFunctionsCases(lsst.utils.tests.TestCase):
+    """Test functions for ISR produce expected outputs.
+    """
+    def setUp(self):
+        self.inputExp = isrMock.TrimmedRawMock().run()
+        self.mi = self.inputExp.getMaskedImage()
+
+    def test_transposeMaskedImage(self):
+        """Expect height and width to be exchanged.
+        """
+        transposed = ipIsr.transposeMaskedImage(self.mi)
+        self.assertEqual(transposed.getImage().getBBox().getHeight(),
+                         self.mi.getImage().getBBox().getWidth())
+        self.assertEqual(transposed.getImage().getBBox().getWidth(),
+                         self.mi.getImage().getBBox().getHeight())
+
+    def test_interpolateDefectList(self):
+        """Expect number of interpolated pixels to be non-zero.
+        """
+        defectList = isrMock.DefectMock().run()
+        self.assertEqual(len(defectList), 1)
+
+        for fallbackValue in (None, -999.0):
+            for haveMask in (True, False):
+                with self.subTest(fallbackValue=fallbackValue, haveMask=haveMask):
+                    if haveMask is False:
+                        if 'INTRP' in self.mi.getMask().getMaskPlaneDict():
+                            self.mi.getMask().removeAndClearMaskPlane('INTRP')
+                    else:
+                        if 'INTRP' not in self.mi.getMask().getMaskPlaneDict():
+                            self.mi.getMask().addMaskPlane('INTRP')
+                    numBit = countMaskedPixels(self.mi, "INTRP")
+                    self.assertEqual(numBit, 0)
+
+    def test_transposeDefectList(self):
+        """Expect bbox dimension values to flip.
+        """
+        defectList = isrMock.DefectMock().run()
+        transposed = ipIsr.transposeDefectList(defectList)
+
+        for d, t in zip(defectList, transposed):
+            self.assertEqual(d.getBBox().getDimensions().getX(), t.getBBox().getDimensions().getY())
+            self.assertEqual(d.getBBox().getDimensions().getY(), t.getBBox().getDimensions().getX())
+
+    def test_makeThresholdMask(self):
+        """Expect list of defects to have elements.
+        """
+        defectList = ipIsr.makeThresholdMask(self.mi, 200, growFootprints=2, maskName='SAT')
+
+        self.assertEqual(len(defectList), 1)
+
+    def test_interpolateFromMask(self):
+        """Expect number of interpolated pixels to be non-zero.
+        """
+        ipIsr.makeThresholdMask(self.mi, 200, growFootprints=2, maskName='SAT')
+        for growFootprints in range(0, 3):
+            interpMaskedImage = ipIsr.interpolateFromMask(self.mi, 2.0,
+                                                          growFootprints=growFootprints, maskName='SAT')
+            numBit = countMaskedPixels(interpMaskedImage, "INTRP")
+            self.assertEqual(numBit, 40800, msg=f"interpolateFromMask with growFootprints={growFootprints}")
+
+    def test_saturationCorrectionInterpolate(self):
+        """Expect number of mask pixels with SAT marked to be non-zero.
+        """
+        corrMaskedImage = ipIsr.saturationCorrection(self.mi, 200, 2.0,
+                                                     growFootprints=2, interpolate=True,
+                                                     maskName='SAT')
+        numBit = countMaskedPixels(corrMaskedImage, "SAT")
+        self.assertEqual(numBit, 40800)
+
+    def test_saturationCorrectionNoInterpolate(self):
+        """Expect number of mask pixels with SAT marked to be non-zero.
+        """
+        corrMaskedImage = ipIsr.saturationCorrection(self.mi, 200, 2.0,
+                                                     growFootprints=2, interpolate=False,
+                                                     maskName='SAT')
+        numBit = countMaskedPixels(corrMaskedImage, "SAT")
+        self.assertEqual(numBit, 40800)
+
+    def test_trimToMatchCalibBBox(self):
+        """Expect bounding boxes to match.
+        """
+        darkExp = isrMock.DarkMock().run()
+        darkMi = darkExp.getMaskedImage()
+
+        nEdge = 2
+        darkMi = darkMi[nEdge:-nEdge, nEdge:-nEdge, afwImage.LOCAL]
+        newInput = ipIsr.trimToMatchCalibBBox(self.mi, darkMi)
+
+        self.assertEqual(newInput.getImage().getBBox(), darkMi.getImage().getBBox())
+
+    def test_darkCorrection(self):
+        """Expect round-trip application to be equal.
+        Expect RuntimeError if sizes are different.
+        """
+        darkExp = isrMock.DarkMock().run()
+        darkMi = darkExp.getMaskedImage()
+
+        mi = self.mi.clone()
+
+        # The `invert` parameter controls the direction of the
+        # application.  This will apply, and un-apply the dark.
+        ipIsr.darkCorrection(self.mi, darkMi, 1.0, 1.0, trimToFit=True)
+        ipIsr.darkCorrection(self.mi, darkMi, 1.0, 1.0, trimToFit=True, invert=True)
+
+        self.assertMaskedImagesAlmostEqual(self.mi, mi, atol=1e-3)
+
+        darkMi = darkMi[1:-1, 1:-1, afwImage.LOCAL]
+
+        with self.assertRaises(RuntimeError):
+            ipIsr.darkCorrection(self.mi, darkMi, 1.0, 1.0, trimToFit=False)
+
+    def test_biasCorrection(self):
+        """Expect smaller median image value after.
+        Expect RuntimeError is sizes are different.
+        """
+        biasExp = isrMock.BiasMock().run()
+        biasMi = biasExp.getMaskedImage()
+
+        mi = self.mi.clone()
+        ipIsr.biasCorrection(self.mi, biasMi, trimToFit=True)
+        self.assertLess(computeImageMedianAndStd(self.mi.getImage())[0],
+                        computeImageMedianAndStd(mi.getImage())[0])
+
+        biasMi = biasMi[1:-1, 1:-1, afwImage.LOCAL]
+
+        with self.assertRaises(RuntimeError):
+            ipIsr.biasCorrection(self.mi, biasMi, trimToFit=False)
+
+    def test_flatCorrection(self):
+        """Expect round-trip application to be equal.
+        Expect RuntimeError if sizes are different or if scaling type isn't known.
+        """
+        flatExp = isrMock.FlatMock().run()
+        flatMi = flatExp.getMaskedImage()
+
+        mi = self.mi.clone()
+        for scaling in ('USER', 'MEAN', 'MEDIAN'):
+            # The `invert` parameter controls the direction of the
+            # application.  This will apply, and un-apply the flat.
+            ipIsr.flatCorrection(self.mi, flatMi, scaling, userScale=1.0, trimToFit=True)
+            ipIsr.flatCorrection(self.mi, flatMi, scaling, userScale=1.0,
+                                 trimToFit=True, invert=True)
+
+            self.assertMaskedImagesAlmostEqual(self.mi, mi, atol=1e-3,
+                                               msg=f"flatCorrection with scaling {scaling}")
+
+        flatMi = flatMi[1:-1, 1:-1, afwImage.LOCAL]
+        with self.assertRaises(RuntimeError):
+            ipIsr.flatCorrection(self.mi, flatMi, 'USER', userScale=1.0, trimToFit=False)
+
+    def test_flatCorrectionUnknown(self):
+        """Raise if an unknown scaling is used.
+
+        The `scaling` parameter must be a known type.  If not, the
+        flat correction will raise a RuntimeError.
+        """
+        flatExp = isrMock.FlatMock().run()
+        flatMi = flatExp.getMaskedImage()
+
+        with self.assertRaises(RuntimeError):
+            ipIsr.flatCorrection(self.mi, flatMi, "UNKNOWN", userScale=1.0, trimToFit=True)
+
+    def test_illumCorrection(self):
+        """Expect larger median value after.
+        Expect RuntimeError if sizes are different.
+        """
+        flatExp = isrMock.FlatMock().run()
+        flatMi = flatExp.getMaskedImage()
+
+        mi = self.mi.clone()
+        ipIsr.illuminationCorrection(self.mi, flatMi, 1.0)
+        self.assertGreater(computeImageMedianAndStd(self.mi.getImage())[0],
+                           computeImageMedianAndStd(mi.getImage())[0])
+
+        flatMi = flatMi[1:-1, 1:-1, afwImage.LOCAL]
+
+        with self.assertRaises(RuntimeError):
+            ipIsr.illuminationCorrection(self.mi, flatMi, 1.0)
+
+    def test_overscanCorrection_isInt(self):
+        """Expect smaller median/smaller std after.
+        Expect exception if overscan fit type isn't known.
+        """
+        inputExp = isrMock.RawMock().run()
+
+        amp = inputExp.getDetector()[0]
+        ampI = inputExp.maskedImage[amp.getRawDataBBox()]
+        overscanI = inputExp.maskedImage[amp.getRawHorizontalOverscanBBox()]
+
+        for fitType in ('MEAN', 'MEDIAN', 'MEANCLIP', 'POLY', 'CHEB',
+                        'NATURAL_SPLINE', 'CUBIC_SPLINE', 'UNKNOWN'):
+            if fitType in ('NATURAL_SPLINE', 'CUBIC_SPLINE'):
+                order = 3
+            else:
+                order = 1
+
+            if fitType == 'UNKNOWN':
+                with self.assertRaises(pexExcept.Exception,
+                                       msg=f"overscanCorrection overscanIsInt fitType: {fitType}"):
+                    ipIsr.overscanCorrection(ampI, overscanI, fitType=fitType,
+                                             order=order, collapseRej=3.0,
+                                             statControl=None, overscanIsInt=True)
+            else:
+                response = ipIsr.overscanCorrection(ampI, overscanI, fitType=fitType,
+                                                    order=order, collapseRej=3.0,
+                                                    statControl=None, overscanIsInt=True)
+            self.assertIsInstance(response, pipeBase.Struct,
+                                  msg=f"overscanCorrection overscanIsInt Bad response: {fitType}")
+            self.assertIsNotNone(response.imageFit,
+                                 msg=f"overscanCorrection overscanIsInt Bad imageFit: {fitType}")
+            self.assertIsNotNone(response.overscanFit,
+                                 msg=f"overscanCorrection overscanIsInt Bad overscanFit: {fitType}")
+            self.assertIsInstance(response.overscanImage, afwImage.MaskedImageF,
+                                  msg=f"overscanCorrection overscanIsInt Bad overscanImage: {fitType}")
+
+    def test_overscanCorrection_isNotInt(self):
+        """Expect smaller median/smaller std after.
+        Expect exception if overscan fit type isn't known.
+        """
+        inputExp = isrMock.RawMock().run()
+
+        amp = inputExp.getDetector()[0]
+        ampI = inputExp.maskedImage[amp.getRawDataBBox()]
+        overscanI = inputExp.maskedImage[amp.getRawHorizontalOverscanBBox()]
+
+        for fitType in ('MEAN', 'MEDIAN', 'MEANCLIP', 'POLY', 'CHEB',
+                        'NATURAL_SPLINE', 'CUBIC_SPLINE', 'UNKNOWN'):
+            if fitType in ('NATURAL_SPLINE', 'CUBIC_SPLINE'):
+                order = 3
+            else:
+                order = 1
+
+            if fitType == 'UNKNOWN':
+                with self.assertRaises(pexExcept.Exception,
+                                       msg=f"overscanCorrection overscanIsNotInt fitType: {fitType}"):
+                    ipIsr.overscanCorrection(ampI, overscanI, fitType=fitType,
+                                             order=order, collapseRej=3.0,
+                                             statControl=None, overscanIsInt=False)
+            else:
+                response = ipIsr.overscanCorrection(ampI, overscanI, fitType=fitType,
+                                                    order=order, collapseRej=3.0,
+                                                    statControl=None, overscanIsInt=False)
+            self.assertIsInstance(response, pipeBase.Struct,
+                                  msg=f"overscanCorrection overscanIsNotInt Bad response: {fitType}")
+            self.assertIsNotNone(response.imageFit,
+                                 msg=f"overscanCorrection overscanIsNotInt Bad imageFit: {fitType}")
+            self.assertIsNotNone(response.overscanFit,
+                                 msg=f"overscanCorrection overscanIsNotInt Bad overscanFit: {fitType}")
+            self.assertIsInstance(response.overscanImage, afwImage.MaskedImageF,
+                                  msg=f"overscanCorrection overscanIsNotInt Bad overscanImage: {fitType}")
+
+    def test_brighterFatterCorrection(self):
+        """Expect smoother image/smaller std before.
+        """
+        bfKern = isrMock.BfKernelMock().run()
+
+        before = computeImageMedianAndStd(self.inputExp.getImage())
+        ipIsr.brighterFatterCorrection(self.inputExp, bfKern, 10, 1e-2, False)
+        after = computeImageMedianAndStd(self.inputExp.getImage())
+
+        self.assertLess(before[1], after[1])
+
+    def test_gainContext(self):
+        """Expect image to be unmodified before and after
+        """
+        mi = self.inputExp.getMaskedImage().clone()
+        with ipIsr.gainContext(self.inputExp, self.inputExp.getImage(), apply=True):
+            pass
+        self.assertMaskedImagesEqual(self.inputExp.getMaskedImage(), mi)
+
+    def test_addDistortionModel(self):
+        """Expect RuntimeError if no model supplied, or incomplete exposure information.
+        """
+        camera = isrMock.IsrMock().getCamera()
+        ipIsr.addDistortionModel(self.inputExp, camera)
+
+        with self.assertRaises(RuntimeError):
+            ipIsr.addDistortionModel(self.inputExp, None)
+
+            self.inputExp.setDetector(None)
+            ipIsr.addDistortionModel(self.inputExp, camera)
+
+            self.inputExp.setWcs(None)
+            ipIsr.addDistortionModel(self.inputExp, camera)
+
+    def test_widenSaturationTrails(self):
+        """Expect more mask pixels with SAT set after.
+        """
+        numBitBefore = countMaskedPixels(self.mi, "SAT")
+
+        ipIsr.widenSaturationTrails(self.mi.getMask())
+        numBitAfter = countMaskedPixels(self.mi, "SAT")
+
+        self.assertGreaterEqual(numBitAfter, numBitBefore)
+
+    def test_setBadRegions(self):
+        """Expect RuntimeError if improper statistic given.
+        Expect a float value otherwise.
+        """
+        for badStatistic in ('MEDIAN', 'MEANCLIP', 'UNKNOWN'):
+            if badStatistic == 'UNKNOWN':
+                with self.assertRaises(RuntimeError,
+                                       msg=f"setBadRegions did not fail for stat {badStatistic}"):
+                    nBad, value = ipIsr.setBadRegions(self.inputExp, badStatistic=badStatistic)
+            else:
+                nBad, value = ipIsr.setBadRegions(self.inputExp, badStatistic=badStatistic)
+                self.assertGreaterEqual(abs(value), 0.0,
+                                        msg=f"setBadRegions did not find valid value for stat {badStatistic}")
+
+    def test_attachTransmissionCurve(self):
+        """Expect no failure and non-None output from attachTransmissionCurve.
+        """
+        curve = isrMock.TransmissionMock().run()
+        combined = ipIsr.attachTransmissionCurve(self.inputExp,
+                                                 opticsTransmission=curve,
+                                                 filterTransmission=curve,
+                                                 sensorTransmission=curve,
+                                                 atmosphereTransmission=curve)
+        self.assertIsNotNone(combined)
+
+    def test_attachTransmissionCurve_None(self):
+        """Expect no failure and non-None output from attachTransmissionCurve.
+        """
+        curve = None
+        combined = ipIsr.attachTransmissionCurve(self.inputExp,
+                                                 opticsTransmission=curve,
+                                                 filterTransmission=curve,
+                                                 sensorTransmission=curve,
+                                                 atmosphereTransmission=curve)
+        self.assertIsNotNone(combined)
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_isrFunctions.py
+++ b/tests/test_isrFunctions.py
@@ -75,7 +75,7 @@ def computeImageMedianAndStd(image):
 
 
 class IsrFunctionsCases(lsst.utils.tests.TestCase):
-    """Test functions for ISR produce expected outputs.
+    """Test that functions for ISR produce expected outputs.
     """
     def setUp(self):
         self.inputExp = isrMock.TrimmedRawMock().run()
@@ -182,13 +182,12 @@ class IsrFunctionsCases(lsst.utils.tests.TestCase):
         self.assertMaskedImagesAlmostEqual(self.mi, mi, atol=1e-3)
 
         darkMi = darkMi[1:-1, 1:-1, afwImage.LOCAL]
-
         with self.assertRaises(RuntimeError):
             ipIsr.darkCorrection(self.mi, darkMi, 1.0, 1.0, trimToFit=False)
 
     def test_biasCorrection(self):
         """Expect smaller median image value after.
-        Expect RuntimeError is sizes are different.
+        Expect RuntimeError if sizes are different.
         """
         biasExp = isrMock.BiasMock().run()
         biasMi = biasExp.getMaskedImage()
@@ -199,13 +198,12 @@ class IsrFunctionsCases(lsst.utils.tests.TestCase):
                         computeImageMedianAndStd(mi.getImage())[0])
 
         biasMi = biasMi[1:-1, 1:-1, afwImage.LOCAL]
-
         with self.assertRaises(RuntimeError):
             ipIsr.biasCorrection(self.mi, biasMi, trimToFit=False)
 
     def test_flatCorrection(self):
         """Expect round-trip application to be equal.
-        Expect RuntimeError if sizes are different or if scaling type isn't known.
+        Expect RuntimeError if sizes are different.
         """
         flatExp = isrMock.FlatMock().run()
         flatMi = flatExp.getMaskedImage()
@@ -250,7 +248,6 @@ class IsrFunctionsCases(lsst.utils.tests.TestCase):
                            computeImageMedianAndStd(mi.getImage())[0])
 
         flatMi = flatMi[1:-1, 1:-1, afwImage.LOCAL]
-
         with self.assertRaises(RuntimeError):
             ipIsr.illuminationCorrection(self.mi, flatMi, 1.0)
 
@@ -393,6 +390,7 @@ class IsrFunctionsCases(lsst.utils.tests.TestCase):
                                                  filterTransmission=curve,
                                                  sensorTransmission=curve,
                                                  atmosphereTransmission=curve)
+        # DM-19707: ip_isr functionality not fully tested by unit tests
         self.assertIsNotNone(combined)
 
     def test_attachTransmissionCurve_None(self):
@@ -404,6 +402,7 @@ class IsrFunctionsCases(lsst.utils.tests.TestCase):
                                                  filterTransmission=curve,
                                                  sensorTransmission=curve,
                                                  atmosphereTransmission=curve)
+        # DM-19707: ip_isr functionality not fully tested by unit tests
         self.assertIsNotNone(combined)
 
 

--- a/tests/test_isrMisc.py
+++ b/tests/test_isrMisc.py
@@ -1,0 +1,104 @@
+#
+# LSST Data Management System
+# Copyright 2008-2017 AURA/LSST.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+
+import unittest
+
+import lsst.afw.geom as afwGeom
+import lsst.utils.tests
+import lsst.ip.isr.straylight as straylight
+import lsst.ip.isr.vignette as vignette
+import lsst.ip.isr.masking as masking
+import lsst.ip.isr.linearize as linearize
+
+import lsst.ip.isr.isrMock as isrMock
+
+
+class IsrMiscCases(lsst.utils.tests.TestCase):
+
+    def setUp(self):
+        self.inputExp = isrMock.TrimmedRawMock().run()
+        self.mi = self.inputExp.getMaskedImage()
+
+    def test_straylight(self):
+        """Assert that the straylight task does not error when given an exposure.
+        """
+        task = straylight.StrayLightTask()
+        task.run(self.inputExp)
+        self.assertTrue(True)
+
+    def test_vignette_noWrite(self):
+        """Assert that the vignette task does not error when given an exposure
+        """
+        config = vignette.VignetteConfig()
+        config.radius = 125.0
+        config.xCenter = 100.0
+        config.yCenter = 100.0
+
+        config.doWriteVignettePolygon = False
+        task = vignette.VignetteTask(config=config)
+        result = task.run(self.inputExp)
+
+        self.assertIsNone(result)
+
+    def test_vignette_doWrite(self):
+        """Assert that the vignette task does not error when given an exposure
+        """
+        config = vignette.VignetteConfig()
+        config.radius = 125.0
+        config.xCenter = 100.0
+        config.yCenter = 100.0
+
+        config.doWriteVignettePolygon = True
+        task = vignette.VignetteTask(config=config)
+        result = task.run(self.inputExp)
+
+        self.assertIsInstance(result, afwGeom.Polygon)
+
+    def test_masking(self):
+        """Assert that the masking task does not error when given an exposure.
+        """
+        task = masking.MaskingTask()
+        result = task.run(self.inputExp)
+
+        self.assertIsNone(result)
+
+    def test_linearize(self):
+        """Assert that the linearize task does not error when a linearity is requested.
+        """
+        for linearityTypeName in ('LookupTable', 'Squared', 'Unknown'):
+            result = linearize.getLinearityTypeByName(linearityTypeName)
+            # These return the actual class to use, so use Equal instead of IsInstance.
+            if linearityTypeName == 'LookupTable':
+                self.assertEqual(result, linearize.LinearizeLookupTable, msg=f"{linearityTypeName}")
+            elif linearityTypeName == 'Squared':
+                self.assertEqual(result, linearize.LinearizeSquared, msg=f"{linearityTypeName}")
+            else:
+                self.assertIsNone(result)
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_isrMisc.py
+++ b/tests/test_isrMisc.py
@@ -42,8 +42,8 @@ class IsrMiscCases(lsst.utils.tests.TestCase):
         """Assert that the straylight task does not error when given an exposure.
         """
         task = straylight.StrayLightTask()
-        task.run(self.inputExp)
-        self.assertTrue(True)
+        with self.assertRaises(NotImplementedError):
+            task.run(self.inputExp, None)
 
     def test_vignette_noWrite(self):
         """Assert that the vignette task does not error when given an exposure

--- a/tests/test_isrMisc.py
+++ b/tests/test_isrMisc.py
@@ -57,6 +57,7 @@ class IsrMiscCases(lsst.utils.tests.TestCase):
         task = vignette.VignetteTask(config=config)
         result = task.run(self.inputExp)
 
+        # DM-19707: ip_isr functionality not fully tested by unit tests
         self.assertIsNone(result)
 
     def test_vignette_doWrite(self):
@@ -74,11 +75,13 @@ class IsrMiscCases(lsst.utils.tests.TestCase):
         self.assertIsInstance(result, afwGeom.Polygon)
 
     def test_masking(self):
-        """Assert that the masking task does not error when given an exposure.
+        """Assert that the camera-specific masking task does not error when
+        given an exposure.
         """
         task = masking.MaskingTask()
         result = task.run(self.inputExp)
 
+        # DM-19707: ip_isr functionality not fully tested by unit tests
         self.assertIsNone(result)
 
     def test_linearize(self):
@@ -92,6 +95,7 @@ class IsrMiscCases(lsst.utils.tests.TestCase):
             elif linearityTypeName == 'Squared':
                 self.assertEqual(result, linearize.LinearizeSquared, msg=f"{linearityTypeName}")
             else:
+                # DM-19707: ip_isr functionality not fully tested by unit tests
                 self.assertIsNone(result)
 
 

--- a/tests/test_isrMock.py
+++ b/tests/test_isrMock.py
@@ -1,0 +1,131 @@
+#
+# LSST Data Management System
+# Copyright 2008-2017 AURA/LSST.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+
+import unittest
+import numpy as np
+
+import lsst.utils.tests
+
+import lsst.afw.image as afwImage
+import lsst.ip.isr.isrMock as isrMock
+
+
+class IsrMockCases(lsst.utils.tests.TestCase):
+    """Test the generation of IsrMock data.
+    """
+    def setUp(self):
+        self.inputExp = isrMock.TrimmedRawMock().run()
+        self.mi = self.inputExp.getMaskedImage()
+
+    def test_simple(self):
+        """Chain raw and calibration mock data.
+
+        This test should confirm the raw data is generated as expected.
+        """
+
+        initialMean = np.median(self.mi.getImage().getArray()[:])
+        initialStd = np.std(self.mi.getImage().getArray()[:])
+
+        bias = isrMock.BiasMock().run()
+        self.mi.getImage().getArray()[:] = (self.mi.getImage().getArray()[:] -
+                                            bias.getMaskedImage().getImage().getArray()[:])
+        newMean = np.median(self.mi.getImage().getArray()[:])
+        newStd = np.std(self.mi.getImage().getArray()[:])
+
+        self.assertLess(newMean, initialMean)
+
+        initialMean = newMean
+        initialStd = newStd
+
+        dark = isrMock.DarkMock().run()
+        self.mi.getImage().getArray()[:] = (self.mi.getImage().getArray()[:] -
+                                            dark.getMaskedImage().getImage().getArray()[:])
+        newMean = np.median(self.mi.getImage().getArray()[:])
+        newStd = np.std(self.mi.getImage().getArray()[:])
+
+        self.assertLess(newMean, initialMean)
+
+        initialMean = newMean
+        initialStd = newStd
+
+        flat = isrMock.FlatMock().run()
+        self.mi.getImage().getArray()[:] = (self.mi.getImage().getArray()[:] -
+                                            flat.getMaskedImage().getImage().getArray()[:])
+        newMean = np.median(self.mi.getImage().getArray()[:])
+        newStd = np.std(self.mi.getImage().getArray()[:])
+
+        self.assertAlmostEqual(newMean, initialMean, -2)
+        self.assertLess(newStd, initialStd)
+
+        initialMean = newMean
+        initialStd = newStd
+
+        fringe = isrMock.FringeMock().run()
+        self.mi.getImage().getArray()[:] = (self.mi.getImage().getArray()[:] -
+                                            fringe.getMaskedImage().getImage().getArray()[:])
+        newMean = np.median(self.mi.getImage().getArray()[:])
+        newStd = np.std(self.mi.getImage().getArray()[:])
+
+        self.assertLess(newMean, initialMean)
+
+    def test_untrimmedSimple(self):
+        """Confirm untrimmed data classes are generated consistently.
+        """
+        exposure = isrMock.RawMock().run()
+        fringe = isrMock.UntrimmedFringeMock().run()
+
+        initialStd = np.std(exposure.getMaskedImage().getImage().getArray()[:])
+
+        diff = (exposure.getMaskedImage().getImage().getArray()[:] -
+                fringe.getMaskedImage().getImage().getArray()[:])
+
+        newStd = np.std(diff[:])
+
+        self.assertLess(newStd, initialStd)
+
+    def test_productTypes(self):
+        """Test non-image data is returned as the expected type.
+        """
+        self.assertIsInstance(isrMock.BfKernelMock().run(), np.ndarray)
+        self.assertIsInstance(isrMock.CrosstalkCoeffMock().run(), np.ndarray)
+
+        self.assertIsInstance(isrMock.DefectMock().run()[0], lsst.meas.algorithms.Defect)
+        self.assertIsInstance(isrMock.TransmissionMock().run(), afwImage.TransmissionCurve)
+
+    def test_edgeCases(self):
+        """Test that improperly specified configurations do not return data.
+        """
+        config = isrMock.IsrMockConfig()
+        self.assertIsNone(isrMock.IsrMock(config=config).run())
+
+        with self.assertRaises(RuntimeError):
+            config.doGenerateData = True
+            isrMock.IsrMock(config=config).run()
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_isrQa.py
+++ b/tests/test_isrQa.py
@@ -1,0 +1,64 @@
+#
+# LSST Data Management System
+# Copyright 2008-2017 AURA/LSST.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+
+import unittest
+import numpy as np
+
+import lsst.utils.tests
+import lsst.ip.isr.isrQa as isrQa
+import lsst.ip.isr.isrMock as isrMock
+
+
+class IsrQaCases(lsst.utils.tests.TestCase):
+
+    def setUp(self):
+        self.inputExp = isrMock.TrimmedRawMock().run()
+        self.mi = self.inputExp.getMaskedImage()
+        self.config = isrQa.IsrQaConfig()
+
+    def test_makeThumbnail(self):
+        """Assert that thumbnails are made and contain non-zero data.
+        """
+        thumb = isrQa.makeThumbnail(self.inputExp, self.config)
+        self.assertTrue(np.nonzero(thumb))
+
+        self.config.thumbnailSatBorder = 0
+        thumb = isrQa.makeThumbnail(self.inputExp, self.config)
+
+        self.assertTrue(np.nonzero(thumb))
+
+    def test_writeThumbnail(self):
+        """Test that a thumbnail can be "written" to disk by a mock dataRef.
+        """
+        dataRef = isrMock.DataRefMock()
+        thumb = isrQa.makeThumbnail(self.inputExp, self.config)
+
+        isrQa.writeThumbnail(dataRef, thumb, "thumbnail")
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_isrQa.py
+++ b/tests/test_isrQa.py
@@ -46,14 +46,6 @@ class IsrQaCases(lsst.utils.tests.TestCase):
 
         self.assertTrue(np.nonzero(thumb))
 
-    def test_writeThumbnail(self):
-        """Test that a thumbnail can be "written" to disk by a mock dataRef.
-        """
-        dataRef = isrMock.DataRefMock()
-        thumb = isrQa.makeThumbnail(self.inputExp, self.config)
-
-        isrQa.writeThumbnail(dataRef, thumb, "thumbnail")
-
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/test_isrTask.py
+++ b/tests/test_isrTask.py
@@ -1,0 +1,529 @@
+#
+# LSST Data Management System
+# Copyright 2008-2017 AURA/LSST.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+
+import unittest
+import numpy as np
+
+import lsst.afw.image as afwImage
+import lsst.ip.isr.isrMock as isrMock
+import lsst.utils.tests
+from lsst.ip.isr.isrTask import (IsrTask, IsrTaskConfig)
+from lsst.ip.isr.isrQa import IsrQaConfig
+from lsst.pipe.base import Struct
+
+
+def countMaskedPixels(maskedImage, maskPlane):
+    """Function to count the number of masked pixels of a given type.
+
+    Parameters
+    ----------
+    maskedImage : `lsst.afw.image.MaskedImage`
+        Image to measure the mask on.
+    maskPlane : `str`
+        Name of the mask plane to count
+
+    Returns
+    -------
+    nMask : `int`
+        Number of masked pixels.
+    """
+    bitMask = maskedImage.getMask().getPlaneBitMask(maskPlane)
+    isBit = maskedImage.getMask().getArray() & bitMask > 0
+    numBit = np.sum(isBit)
+    return numBit
+
+
+def computeImageMedianAndStd(image):
+    """Function to calculate median and std of image data.
+
+    Parameters
+    ----------
+    image : `lsst.afw.image.Image`
+        Image to measure statistics on.
+
+    Returns
+    -------
+    median : `float`
+        Image median.
+    std : `float`
+        Image stddev.
+    """
+    median = np.nanmedian(image.getArray())
+    std = np.nanstd(image.getArray())
+
+    return (median, std)
+
+
+class IsrTaskTestCases(lsst.utils.tests.TestCase):
+    """Test IsrTask methods with trimmed raw data.
+    """
+    def setUp(self):
+        self.config = IsrTaskConfig()
+        self.config.qa = IsrQaConfig()
+        self.task = IsrTask(config=self.config)
+        self.dataRef = isrMock.DataRefMock()
+        self.camera = isrMock.IsrMock().getCamera()
+
+        self.inputExp = isrMock.TrimmedRawMock().run()
+        self.amp = self.inputExp.getDetector()[0]
+        self.mi = self.inputExp.getMaskedImage()
+
+    def validateIsrData(self, results):
+        """results should be a struct with components that are
+        not None if included in the configuration file.
+        """
+        self.assertIsInstance(results, Struct)
+        if self.config.doBias is True:
+            self.assertIsNotNone(results.bias)
+        if self.config.doDark is True:
+            self.assertIsNotNone(results.dark)
+        if self.config.doFlat is True:
+            self.assertIsNotNone(results.flat)
+        if self.config.doFringe is True:
+            self.assertIsNotNone(results.fringes)
+        if self.config.doDefect is True:
+            self.assertIsNotNone(results.defects)
+        if self.config.doBrighterFatter is True:
+            self.assertIsNotNone(results.bfKernel)
+        if self.config.doAttachTransmissionCurve is True:
+            self.assertIsNotNone(results.opticsTransmission)
+            self.assertIsNotNone(results.filterTransmission)
+            self.assertIsNotNone(results.sensorTransmission)
+            self.assertIsNotNone(results.atmosphereTransmission)
+
+    def test_readIsrData_noTrans(self):
+        """Test that all necessary calibration frames are retrieved.
+        """
+        self.config.doAttachTransmissionCurve = False
+        self.task = IsrTask(config=self.config)
+        results = self.task.readIsrData(self.dataRef, self.inputExp)
+        self.validateIsrData(results)
+
+    def test_readIsrData_withTrans(self):
+        """Test that all necessary calibration frames are retrieved.
+        """
+        self.config.doAttachTransmissionCurve = True
+        self.task = IsrTask(config=self.config)
+        results = self.task.readIsrData(self.dataRef, self.inputExp)
+        self.validateIsrData(results)
+
+    def test_ensureExposure(self):
+        """Test that an exposure has a usable instance class.
+        """
+        self.assertIsInstance(self.task.ensureExposure(self.inputExp, self.camera, 0),
+                              afwImage.Exposure)
+
+    def test_convertItoF(self):
+        """Test conversion from integer to floating point pixels.
+        """
+        self.assertIsInstance(self.task.convertIntToFloat(self.inputExp).getImage()[1, 1],
+                              float)
+
+    def test_updateVariance(self):
+        """Expect The variance image should have a larger median value after
+        this operation.
+        """
+        statBefore = computeImageMedianAndStd(self.inputExp.variance[self.amp.getBBox()])
+        self.task.updateVariance(self.inputExp, self.amp)
+        statAfter = computeImageMedianAndStd(self.inputExp.variance[self.amp.getBBox()])
+        self.assertGreater(statAfter[0], statBefore[0])
+
+    def test_darkCorrection(self):
+        """Expect the median image value should decrease after this operation.
+        """
+        darkIm = isrMock.DarkMock().run()
+
+        statBefore = computeImageMedianAndStd(self.inputExp.image[self.amp.getBBox()])
+        self.task.darkCorrection(self.inputExp, darkIm)
+        statAfter = computeImageMedianAndStd(self.inputExp.image[self.amp.getBBox()])
+        self.assertLess(statAfter[0], statBefore[0])
+
+    def test_darkCorrection_noVisitInfo(self):
+        """Expect the median image value should decrease after this operation.
+        """
+        darkIm = isrMock.DarkMock().run()
+        darkIm.getInfo().setVisitInfo(None)
+
+        statBefore = computeImageMedianAndStd(self.inputExp.image[self.amp.getBBox()])
+        self.task.darkCorrection(self.inputExp, darkIm)
+        statAfter = computeImageMedianAndStd(self.inputExp.image[self.amp.getBBox()])
+        self.assertLess(statAfter[0], statBefore[0])
+
+    def test_flatCorrection(self):
+        """Expect the image median should increase (divide by < 1).
+        """
+        flatIm = isrMock.FlatMock().run()
+
+        statBefore = computeImageMedianAndStd(self.inputExp.image[self.amp.getBBox()])
+        self.task.flatCorrection(self.inputExp, flatIm)
+        statAfter = computeImageMedianAndStd(self.inputExp.image[self.amp.getBBox()])
+        self.assertGreater(statAfter[1], statBefore[1])
+
+    def test_saturationDetection(self):
+        """Expect the saturation level detection/masking to scale with
+        threshold.
+        """
+        self.amp.setSaturation(1000.0)
+        self.task.saturationDetection(self.inputExp, self.amp)
+        countBefore = countMaskedPixels(self.mi, "SAT")
+
+        self.amp.setSaturation(25.0)
+        self.task.saturationDetection(self.inputExp, self.amp)
+        countAfter = countMaskedPixels(self.mi, "SAT")
+
+        self.assertLessEqual(countBefore, countAfter)
+
+    def test_measureBackground(self):
+        """Expect the background measurement runs successfully and to save
+        metadata values.
+        """
+        self.config.qa.flatness.meshX = 20
+        self.config.qa.flatness.meshY = 20
+        self.task.measureBackground(self.inputExp, self.config.qa)
+        self.assertIsNotNone(self.inputExp.getMetadata().getScalar('SKYLEVEL'))
+
+    def test_flatContext(self):
+        """Expect the flat context manager runs successfully and leaves the
+        image data the same.
+        """
+        darkExp = isrMock.DarkMock().run()
+        flatExp = isrMock.FlatMock().run()
+
+        mi = self.inputExp.getMaskedImage().clone()
+        with self.task.flatContext(self.inputExp, flatExp, darkExp):
+            self.assertTrue(True)
+
+        self.assertMaskedImagesAlmostEqual(mi, self.inputExp.getMaskedImage(), -3)
+
+
+class IsrTaskUnTrimmedTestCases(lsst.utils.tests.TestCase):
+    """Test IsrTask methods using untrimmed raw data.
+    """
+    def setUp(self):
+        self.config = IsrTaskConfig()
+        self.config.qa = IsrQaConfig()
+        self.task = IsrTask(config=self.config)
+
+        self.mockConfig = isrMock.IsrMockConfig()
+        self.mockConfig.isTrimmed = False
+        self.doGenerateImage = True
+        self.dataRef = isrMock.DataRefMock(config=self.mockConfig)
+        self.camera = isrMock.IsrMock(config=self.mockConfig).getCamera()
+
+        self.inputExp = isrMock.RawMock(config=self.mockConfig).run()
+        self.amp = self.inputExp.getDetector()[0]
+        self.mi = self.inputExp.getMaskedImage()
+
+    def batchSetConfiguration(self, value):
+        """Set the configuration state to a consistent value.
+
+        Disable options we do not need as well.
+
+        Parameters
+        ----------
+        value : `bool`
+            Value to switch common ISR configuration options to.
+        """
+        self.config.qa.flatness.meshX = 20
+        self.config.qa.flatness.meshY = 20
+        self.config.doWrite = False
+        self.config.doLinearize = False
+        self.config.doCrosstalk = False
+
+        self.config.doConvertIntToFloat = value
+        self.config.doSaturation = value
+        self.config.doSuspect = value
+        self.config.doSetBadRegions = value
+        self.config.doOverscan = value
+        self.config.doBias = value
+        self.config.doVariance = value
+        self.config.doWidenSaturationTrails = value
+        self.config.doBrighterFatter = value
+        self.config.doDefect = value
+        self.config.doSaturationInterpolation = value
+        self.config.doDark = value
+        self.config.doStrayLight = value
+        self.config.doFlat = value
+        self.config.doFringe = value
+        self.config.doAddDistortionModel = value
+        self.config.doMeasureBackground = value
+        self.config.doVignette = value
+        self.config.doAttachTransmissionCurve = value
+        self.config.doUseOpticsTransmission = value
+        self.config.doUseFilterTransmission = value
+        self.config.doUseSensorTransmission = value
+        self.config.doUseAtmosphereTransmission = value
+        self.config.qa.saveStats = value
+        self.config.qa.doThumbnailOss = value
+        self.config.qa.doThumbnailFlattened = value
+
+        self.config.doApplyGains = not value
+        self.config.doCameraSpecificMasking = value
+        self.config.vignette.doWriteVignettePolygon = value
+
+    def validateIsrResults(self):
+        """results should be a struct with components that are
+        not None if included in the configuration file.
+
+        Returns
+        -------
+        results : `pipeBase.Struct`
+            Results struct generated from the current ISR configuration.
+        """
+        self.task = IsrTask(config=self.config)
+        results = self.task.run(self.inputExp,
+                                camera=self.camera,
+                                bias=self.dataRef.get("bias"),
+                                dark=self.dataRef.get("dark"),
+                                flat=self.dataRef.get("flat"),
+                                bfKernel=self.dataRef.get("bfKernel"),
+                                defects=self.dataRef.get("defects"),
+                                fringes=Struct(fringes=self.dataRef.get("fringe"), seed=1234),
+                                opticsTransmission=self.dataRef.get("transmission_"),
+                                filterTransmission=self.dataRef.get("transmission_"),
+                                sensorTransmission=self.dataRef.get("transmission_"),
+                                atmosphereTransmission=self.dataRef.get("transmission_")
+                                )
+
+        self.assertIsInstance(results, Struct)
+        self.assertIsInstance(results.exposure, afwImage.Exposure)
+        return results
+
+    def test_overscanCorrection(self):
+        """Expect that this should reduce the image variance with a full fit.
+        The default fitType of MEDIAN will reduce the median value.
+
+        This needs to operate on a RawMock() to have overscan data to use.
+
+        The output types may be different when fitType != MEDIAN.
+        """
+        statBefore = computeImageMedianAndStd(self.inputExp.image[self.amp.getRawDataBBox()])
+
+        oscanResults = self.task.overscanCorrection(self.inputExp, self.amp)
+        self.assertIsInstance(oscanResults, Struct)
+        self.assertIsInstance(oscanResults.imageFit, float)
+        self.assertIsInstance(oscanResults.overscanFit, float)
+        self.assertIsInstance(oscanResults.overscanImage, afwImage.MaskedImageF)
+
+        statAfter = computeImageMedianAndStd(self.inputExp.image[self.amp.getRawDataBBox()])
+        self.assertLess(statAfter[0], statBefore[0])
+
+    def test_runDataRef(self):
+        """Expect a dataRef to be handled correctly.
+        """
+        self.config.doLinearize = False
+        self.config.doWrite = False
+        self.task = IsrTask(config=self.config)
+        print(self.task.config)
+        results = self.task.runDataRef(self.dataRef)
+
+        self.assertIsInstance(results, Struct)
+        self.assertIsInstance(results.exposure, afwImage.Exposure)
+
+    def test_run_allTrue(self):
+        """Expect successful run with expected outputs when all non-exclusive
+        configuration options are on.
+
+        Output results should be tested more precisely by the
+        individual function tests.
+
+        """
+        self.batchSetConfiguration(True)
+        self.validateIsrResults()
+
+    def test_run_allFalse(self):
+        """Expect successful run with expected outputs when all non-exclusive
+        configuration options are off.
+
+        Output results should be tested more precisely by the
+        individual function tests.
+
+        """
+        self.batchSetConfiguration(False)
+        self.validateIsrResults()
+
+    def test_failCases(self):
+        """Expect failure with crosstalk enabled.
+
+        Output results should be tested more precisely by the
+        individual function tests.
+        """
+        self.batchSetConfiguration(True)
+
+        # This breaks it
+        self.config.doCrosstalk = True
+
+        with self.assertRaises(RuntimeError):
+            self.validateIsrResults()
+
+    def test_maskingCase_noMasking(self):
+        """Test masking cases of configuration parameters.
+        """
+        self.batchSetConfiguration(True)
+        self.config.overscanFitType = "POLY"
+        self.config.overscanOrder = 1
+
+        self.config.doSaturation = False
+        self.config.doWidenSaturationTrails = False
+        self.config.doSaturationInterpolation = False
+        self.config.doSuspect = False
+        self.config.doSetBadRegions = False
+        self.config.doDefect = False
+        self.config.doBrighterFatter = False
+
+        results = self.validateIsrResults()
+
+        self.assertEqual(countMaskedPixels(results.exposure, "SAT"), 0)
+        self.assertEqual(countMaskedPixels(results.exposure, "INTRP"), 0)
+        self.assertEqual(countMaskedPixels(results.exposure, "SUSPECT"), 0)
+        self.assertEqual(countMaskedPixels(results.exposure, "BAD"), 0)
+
+    def test_maskingCase_satMasking(self):
+        """Test masking cases of configuration parameters.
+        """
+        self.batchSetConfiguration(True)
+        self.config.overscanFitType = "POLY"
+        self.config.overscanOrder = 1
+
+        self.config.saturation = 20000.0
+        self.config.doSaturation = True
+        self.config.doWidenSaturationTrails = True
+
+        self.config.doSaturationInterpolation = False
+        self.config.doSuspect = False
+        self.config.doSetBadRegions = False
+        self.config.doDefect = False
+        self.config.doBrighterFatter = False
+
+        results = self.validateIsrResults()
+
+        self.assertEqual(countMaskedPixels(results.exposure, "SAT"), 0)
+        self.assertEqual(countMaskedPixels(results.exposure, "INTRP"), 0)
+        self.assertEqual(countMaskedPixels(results.exposure, "SUSPECT"), 0)
+        self.assertEqual(countMaskedPixels(results.exposure, "BAD"), 0)
+
+    def test_maskingCase_satMaskingAndInterp(self):
+        """Test masking cases of configuration parameters.
+        """
+        self.batchSetConfiguration(True)
+        self.config.overscanFitType = "POLY"
+        self.config.overscanOrder = 1
+
+        self.config.saturation = 20000.0
+        self.config.doSaturation = True
+        self.config.doWidenSaturationTrails = True
+        self.config.doSaturationInterpolation = True
+
+        self.config.doSuspect = False
+        self.config.doSetBadRegions = False
+        self.config.doDefect = False
+        self.config.doBrighterFatter = False
+
+        results = self.validateIsrResults()
+
+        self.assertEqual(countMaskedPixels(results.exposure, "SAT"), 0)
+        self.assertEqual(countMaskedPixels(results.exposure, "INTRP"), 0)
+        self.assertEqual(countMaskedPixels(results.exposure, "SUSPECT"), 0)
+        self.assertEqual(countMaskedPixels(results.exposure, "BAD"), 0)
+
+    def test_maskingCase_throughEdge(self):
+        """Test masking cases of configuration parameters.
+        """
+        self.batchSetConfiguration(True)
+        self.config.overscanFitType = "POLY"
+        self.config.overscanOrder = 1
+
+        self.config.saturation = 20000.0
+        self.config.doSaturation = True
+        self.config.doWidenSaturationTrails = True
+        self.config.doSaturationInterpolation = True
+        self.config.numEdgeSuspect = 5
+        self.config.doSuspect = True
+
+        self.config.doSetBadRegions = False
+        self.config.doDefect = False
+        self.config.doBrighterFatter = False
+
+        results = self.validateIsrResults()
+
+        self.assertEqual(countMaskedPixels(results.exposure, "SAT"), 0)
+        self.assertEqual(countMaskedPixels(results.exposure, "INTRP"), 0)
+        self.assertEqual(countMaskedPixels(results.exposure, "SUSPECT"), 0)
+        self.assertEqual(countMaskedPixels(results.exposure, "BAD"), 0)
+
+    def test_maskingCase_throughDefects(self):
+        """Test masking cases of configuration parameters.
+        """
+        self.batchSetConfiguration(True)
+        self.config.overscanFitType = "POLY"
+        self.config.overscanOrder = 1
+
+        self.config.saturation = 20000.0
+        self.config.doSaturation = True
+        self.config.doWidenSaturationTrails = True
+        self.config.doSaturationInterpolation = True
+        self.config.numEdgeSuspect = 5
+        self.config.doSuspect = True
+        self.config.doDefect = True
+
+        self.config.doSetBadRegions = False
+        self.config.doBrighterFatter = False
+
+        results = self.validateIsrResults()
+
+        self.assertEqual(countMaskedPixels(results.exposure, "SAT"), 0)
+        self.assertEqual(countMaskedPixels(results.exposure, "INTRP"), 2000)
+        self.assertEqual(countMaskedPixels(results.exposure, "SUSPECT"), 3940)
+        self.assertEqual(countMaskedPixels(results.exposure, "BAD"), 2000)
+
+    def test_maskingCase_throughBad(self):
+        """Test masking cases of configuration parameters.
+        """
+        self.batchSetConfiguration(True)
+        self.config.overscanFitType = "POLY"
+        self.config.overscanOrder = 1
+
+        self.config.saturation = 20000.0
+        self.config.doSaturation = True
+        self.config.doWidenSaturationTrails = True
+        self.config.doSaturationInterpolation = True
+
+        self.config.doSuspect = True
+        self.config.doDefect = True
+        self.config.doSetBadRegions = True
+        self.config.doBrighterFatter = False
+
+        results = self.validateIsrResults()
+
+        self.assertEqual(countMaskedPixels(results.exposure, "SAT"), 0)
+        self.assertEqual(countMaskedPixels(results.exposure, "INTRP"), 2000)
+        self.assertEqual(countMaskedPixels(results.exposure, "SUSPECT"), 0)
+        self.assertEqual(countMaskedPixels(results.exposure, "BAD"), 2000)
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_linearizeLookupTable.py
+++ b/tests/test_linearizeLookupTable.py
@@ -127,6 +127,16 @@ class LinearizeLookupTableTestCase(lsst.utils.tests.TestCase):
         with self.assertRaises(RuntimeError):
             llt(image, detBadLinType)
 
+        # wrong dimension
+        badTable = table[..., np.newaxis]
+        with self.assertRaises(RuntimeError):
+            LinearizeLookupTable(table=badTable, detector=self.detector)
+
+        # wrong size
+        badTable = np.resize(table, (2, 8))
+        with self.assertRaises(RuntimeError):
+            LinearizeLookupTable(table=badTable, detector=self.detector)
+
     def testKnown(self):
         """!Test a few known values
         """

--- a/tests/test_measureCrosstalk.py
+++ b/tests/test_measureCrosstalk.py
@@ -1,0 +1,124 @@
+#
+# LSST Data Management System
+# Copyright 2008-2017 AURA/LSST.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+
+import unittest
+import numpy as np
+
+import lsst.utils.tests
+from lsst.ip.isr.measureCrosstalk import (MeasureCrosstalkTask, MeasureCrosstalkConfig)
+import lsst.ip.isr.isrMock as isrMock
+
+
+class MeasureCrosstalkTaskCases(lsst.utils.tests.TestCase):
+
+    def testMeasureCrosstalkTaskTrimmed(self):
+        """Measure crosstalk from a sequence of mocked images.
+        """
+        config = isrMock.IsrMockConfig()
+        config.rngSeed = 12345
+        config.doAddCrosstalk = True
+        config.doAddSky = True
+        config.doAddSource = True
+        config.skyLevel = 0.0
+        config.readNoise = 0.0
+        mcConfig = MeasureCrosstalkConfig()
+        mcConfig.threshold = 4000
+        mct = MeasureCrosstalkTask(config=mcConfig)
+        fullResult = []
+
+        config.isTrimmed = True
+
+        for idx in range(0, 10):
+            config.rngSeed = 12345 + idx * 1000
+            config.sourceAmp = [0, 1, 2, 3, 4, 5, 6, 7]
+            config.sourceFlux = [45000.0, 45000.0, 45000.0, 45000.0,
+                                 45000.0, 45000.0, 45000.0, 45000.0]
+            config.sourceX = [50.0, 25.0, 75.0, 12.5, 37.5, 67.5, 82.5]
+            config.sourceY = [25.0, 12.5, 37.5, 26.75, 22.25, 12.5, 37.5]
+            exposure = isrMock.CalibratedRawMock(config=config).run()
+            result = mct.run(exposure, dataId=None)
+            fullResult.append(result)
+
+        coeff, coeffSig, coeffNum = mct.reduce(fullResult)
+
+        # Needed because measureCrosstalk cannot find coefficients equal to 0.0
+        coeff = np.nan_to_num(coeff)
+        coeffSig = np.nan_to_num(coeffSig)
+
+        expectation = isrMock.CrosstalkCoeffMock().run()
+        coeffErr = abs(coeff - expectation) <= coeffSig
+
+        # DM-18528 This doesn't always fully converge, so be permissive
+        # for now.  This is also more challenging on the test
+        # chip due to density issues.
+        self.assertTrue(np.any(coeffErr))
+
+    def testMeasureCrosstalkTaskUntrimmed(self):
+        """Measure crosstalk from a sequence of mocked images.
+        """
+        config = isrMock.IsrMockConfig()
+        config.rngSeed = 12345
+        config.doAddCrosstalk = True
+        config.doAddSky = True
+        config.doAddSource = True
+        config.skyLevel = 0.0
+        config.readNoise = 0.0
+        mcConfig = MeasureCrosstalkConfig()
+        mcConfig.threshold = 4000
+        mct = MeasureCrosstalkTask(config=mcConfig)
+        fullResult = []
+
+        config.isTrimmed = False
+
+        for idx in range(0, 10):
+            config.rngSeed = 12345 + idx * 1000
+            config.sourceAmp = [0, 1, 2, 3, 4, 5, 6, 7]
+            config.sourceFlux = [45000.0, 45000.0, 45000.0, 45000.0,
+                                 45000.0, 45000.0, 45000.0, 45000.0]
+            config.sourceX = [50.0, 25.0, 75.0, 12.5, 37.5, 67.5, 82.5]
+            config.sourceY = [25.0, 12.5, 37.5, 26.75, 22.25, 12.5, 37.5]
+            exposure = isrMock.CalibratedRawMock(config=config).run()
+            result = mct.run(exposure, dataId=None)
+            fullResult.append(result)
+
+        coeff, coeffSig, coeffNum = mct.reduce(fullResult)
+
+        # Needed because measureCrosstalk cannot find coefficients equal to 0.0
+        coeff = np.nan_to_num(coeff)
+        coeffSig = np.nan_to_num(coeffSig)
+
+        expectation = isrMock.CrosstalkCoeffMock().run()
+        coeffErr = abs(coeff - expectation) <= coeffSig
+
+        # DM-18528 This doesn't always fully converge, so be permissive
+        # for now.  This is also more challenging on the test
+        # chip due to density issues.
+        self.assertTrue(np.any(coeffErr))
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_saturationCorrection.py
+++ b/tests/test_saturationCorrection.py
@@ -31,6 +31,11 @@ import lsst.ip.isr as ipIsr
 class IsrTestCases(lsst.utils.tests.TestCase):
 
     def testSaturation(self):
+        """Test saturation threshold masking and interpolation.
+
+        The test image used here is a simulated 20x20 square with a
+        10-pixel long defect in the y-direction.
+        """
         saturation = 1000
 
         bbox = lsst.geom.Box2I(lsst.geom.Point2I(0, 0), lsst.geom.Point2I(19, 19))


### PR DESCRIPTION
These tests have finally converged with the addition of the `ip_isr/isrMock.py` code to supply "realistic" simulated data to check.  Running these tests uncovered some bugs in the ISR code, which has now been corrected.

The code coverage is now much better than previously, with the only major untested code being in the methods to support Gen3 butler/processing.