### PR TITLE
DM-18703 constructFlat.py --config isr.doCrosstalkBeforeAssemble=False raises a LengthError exception

### DIFF
--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -1143,7 +1143,7 @@ class IsrTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
 
         if self.config.doCrosstalk and self.config.doCrosstalkBeforeAssemble:
             self.log.info("Applying crosstalk correction.")
-            self.crosstalk.run(ccdExposure, crosstalkSources=crosstalkSources)
+            self.crosstalk.run(ccdExposure, crosstalkSources=crosstalkSources, isTrimmed=False)
             self.debugView(ccdExposure, "doCrosstalk")
 
         if self.config.doAssembleCcd:
@@ -1192,7 +1192,7 @@ class IsrTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
 
         if self.config.doCrosstalk and not self.config.doCrosstalkBeforeAssemble:
             self.log.info("Applying crosstalk correction.")
-            self.crosstalk.run(ccdExposure, crosstalkSources=crosstalkSources)
+            self.crosstalk.run(ccdExposure, crosstalkSources=crosstalkSources, isTrimmed=True)
             self.debugView(ccdExposure, "doCrosstalk")
 
         if self.config.doWidenSaturationTrails:

--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -1143,7 +1143,7 @@ class IsrTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
 
         if self.config.doCrosstalk and self.config.doCrosstalkBeforeAssemble:
             self.log.info("Applying crosstalk correction.")
-            self.crosstalk.run(ccdExposure, crosstalkSources=crosstalkSources, isTrimmed=False)
+            self.crosstalk.run(ccdExposure, crosstalkSources=crosstalkSources)
             self.debugView(ccdExposure, "doCrosstalk")
 
         if self.config.doAssembleCcd:


### PR DESCRIPTION
In addition to the length error, this ticket also includes crosstalk correction in ip_isr to not subtract background levels calculating the corrected pixels, but to include that background when calculating the mask of significant CT pixels.