### PR TITLE
DM-19717: Add setup_module to ensure memory tests are run.

### DIFF
--- a/tests/test_assembleCcd.py
+++ b/tests/test_assembleCcd.py
@@ -87,6 +87,10 @@ class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass
 
 
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
 if __name__ == "__main__":
     lsst.utils.tests.init()
     unittest.main()

--- a/tests/test_isrFunctions.py
+++ b/tests/test_isrFunctions.py
@@ -410,6 +410,10 @@ class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass
 
 
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
 if __name__ == "__main__":
     lsst.utils.tests.init()
     unittest.main()

--- a/tests/test_isrMisc.py
+++ b/tests/test_isrMisc.py
@@ -103,6 +103,10 @@ class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass
 
 
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
 if __name__ == "__main__":
     lsst.utils.tests.init()
     unittest.main()

--- a/tests/test_isrMock.py
+++ b/tests/test_isrMock.py
@@ -126,6 +126,10 @@ class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass
 
 
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
 if __name__ == "__main__":
     lsst.utils.tests.init()
     unittest.main()

--- a/tests/test_isrQa.py
+++ b/tests/test_isrQa.py
@@ -51,6 +51,10 @@ class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass
 
 
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
 if __name__ == "__main__":
     lsst.utils.tests.init()
     unittest.main()

--- a/tests/test_isrTask.py
+++ b/tests/test_isrTask.py
@@ -536,6 +536,10 @@ class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass
 
 
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
 if __name__ == "__main__":
     lsst.utils.tests.init()
     unittest.main()

--- a/tests/test_measureCrosstalk.py
+++ b/tests/test_measureCrosstalk.py
@@ -116,6 +116,10 @@ class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass
 
 
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
 if __name__ == "__main__":
     lsst.utils.tests.init()
     unittest.main()


### PR DESCRIPTION
The new unit tests introduced in DM-15683 did not ensure that lsst.utils.tests.init() was called.  This ticket fixes that.