### PR TITLE
DM-20109: Improve ip_isr log messages to be more explicit

### DIFF
--- a/python/lsst/ip/isr/assembleCcdTask.py
+++ b/python/lsst/ip/isr/assembleCcdTask.py
@@ -105,27 +105,6 @@ class AssembleCcdTask(pipeBase.Task):
 
     @section ip_isr_assemble_Example A complete example of using AssembleCcdTask
 
-    This code is in runAssembleTask.py in the examples directory, and can be run as @em e.g.
-    @code
-    python examples/runAssembleTask.py
-    @endcode
-
-    @dontinclude runAssembleTask.py
-    Import the task.  There are other imports.  Read the source file for more info.
-    @skipline AssembleCcdTask
-
-    @dontinclude exampleUtils.py
-    Create some input images with the help of some utilities in examples/exampleUtils.py
-    @skip makeAssemblyInput
-    @until inputData
-    The above numbers can be changed.  The assumption that the readout corner is flipped on every other amp is
-    hardcoded in createDetector.
-
-    @dontinclude runAssembleTask.py
-    Run the assembler task
-    @skip runAssembler
-    @until frame += 1
-
     <HR>
     To investigate the @ref ip_isr_assemble_Debug, put something like
     @code{.py}

--- a/python/lsst/ip/isr/crosstalk.py
+++ b/python/lsst/ip/isr/crosstalk.py
@@ -100,7 +100,7 @@ class CrosstalkTask(Task):
         detector = exposure.getDetector()
         if not detector.hasCrosstalk():
             raise RuntimeError("Attempted to correct crosstalk without crosstalk coefficients")
-        self.log.info("Applying crosstalk correction")
+        self.log.info("Applying crosstalk correction.")
         subtractCrosstalk(exposure, minPixelToMask=self.config.minPixelToMask,
                           crosstalkStr=self.config.crosstalkMaskPlane, isTrimmed=isTrimmed,
                           backgroundMethod=self.config.crosstalkBackgroundMethod)

--- a/python/lsst/ip/isr/isrFunctions.py
+++ b/python/lsst/ip/isr/isrFunctions.py
@@ -740,6 +740,13 @@ def brighterFatterCorrection(exposure, kernel, maxIter, threshold, applyGain):
         If True, then the exposure values are scaled by the gain prior
         to correction.
 
+    Returns
+    -------
+    diff : `float`
+        Final difference between iterations achieved in correction.
+    iteration : `int`
+        Number of iterations used to calculate correction.
+
     Notes
     -----
     This correction takes a kernel that has been derived from flat
@@ -827,13 +834,10 @@ def brighterFatterCorrection(exposure, kernel, maxIter, threshold, applyGain):
                     break
                 prev_image[:, :] = tmpArray[:, :]
 
-                #        if iteration == maxIter - 1:
-                #            self.log.warn("Brighter fatter correction did not converge,
-                #                          final difference %f" % diff)
-
-                #    self.log.info("Finished brighter fatter in %d iterations" % (iteration + 1))
         image.getArray()[startY + 1:endY - 1, startX + 1:endX - 1] += \
             corr[startY + 1:endY - 1, startX + 1:endX - 1]
+
+    return diff, iteration
 
 
 @contextmanager


### PR DESCRIPTION
Clarify ISR log messages, comments, and docstrings.

Change isrFunctions.brighterFatterCorrection to return final
difference and iteration count, so an old log message can be restored.

Remove old out-of-date documentation that was causing build warnings.