### PR TITLE
DM-20112: ip_isr is not handling BAD pixels as expected

### DIFF
--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -1399,8 +1399,20 @@ class IsrTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
         if self.config.doSaveInterpPixels:
             preInterpExp = ccdExposure.clone()
 
+        # Reset and interpolate bad pixels.
+        #
+        # Large contiguous bad regions (which should have the BAD mask
+        # bit set) should have their values set to the image median.
+        # This group should include defects and bad amplifiers. As the
+        # area covered by these defects are large, there's little
+        # reason to expect that interpolation would provide a more
+        # useful value.
+        #
+        # Smaller defects can be safely interpolated after the larger
+        # regions have had their pixel values reset.  This ensures
+        # that the remaining defects adjacent to bad amplifiers (as an
+        # example) do not attempt to interpolate extreme values.
         if self.config.doSetBadRegions:
-            # This is like an interpolation.
             badPixelCount, badPixelValue = isrFunctions.setBadRegions(ccdExposure)
             if badPixelCount > 0:
                 self.log.info("Set %d BAD pixels to %f." % (badPixelCount, badPixelValue))

--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -1693,6 +1693,7 @@ class IsrTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
                                             self.config.suspectMaskName])
         if numpy.all(maskView.getArray() & maskVal > 0):
             badAmp = True
+            maskView |= maskView.getPlaneBitMask("BAD")
 
         return badAmp
 

--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -1312,7 +1312,7 @@ class IsrTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
             interpExp = ccdExposure.clone()
             with self.flatContext(interpExp, flat, dark):
                 isrFunctions.interpolateFromMask(
-                    maskedImage=ccdExposure.getMaskedImage(),
+                    maskedImage=interpExp.getMaskedImage(),
                     fwhm=self.config.fwhm,
                     growSaturatedFootprints=self.config.growSaturationFootprintSize,
                     maskNameList=self.config.maskListToInterpolate
@@ -1399,6 +1399,12 @@ class IsrTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
         if self.config.doSaveInterpPixels:
             preInterpExp = ccdExposure.clone()
 
+        if self.config.doSetBadRegions:
+            # This is like an interpolation.
+            badPixelCount, badPixelValue = isrFunctions.setBadRegions(ccdExposure)
+            if badPixelCount > 0:
+                self.log.info("Set %d BAD pixels to %f." % (badPixelCount, badPixelValue))
+
         if self.config.doInterpolate:
             self.log.info("Interpolating masked pixels.")
             isrFunctions.interpolateFromMask(
@@ -1407,12 +1413,6 @@ class IsrTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
                 growSaturatedFootprints=self.config.growSaturationFootprintSize,
                 maskNameList=list(self.config.maskListToInterpolate)
             )
-
-        if self.config.doSetBadRegions:
-            # This is like an interpolation.
-            badPixelCount, badPixelValue = isrFunctions.setBadRegions(ccdExposure)
-            if badPixelCount > 0:
-                self.log.info("Set %d BAD pixels to %f." % (badPixelCount, badPixelValue))
 
         self.roughZeroPoint(ccdExposure)
 

--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -2310,6 +2310,11 @@ class IsrTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
             display = getDisplay(frame)
             display.scale('asinh', 'zscale')
             display.mtv(exposure)
+            prompt = "Press Enter to continue [c]... "
+            while True:
+                ans = input(prompt).lower()
+                if ans in ("", "c",):
+                    break
 
 
 class FakeAmp(object):


### PR DESCRIPTION
Move BAD pixel value setting before interpolation.

With interpolation on, these pixels are interpolated, which means they
do not receive the image median value.  This may skew the
interpolation.

Fix interpolation exposure choice bug.