### PR TITLE
DM-22191: isr for yaml cameras is broken due to zero value for suspectLevel

### DIFF
--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -272,7 +272,7 @@ class IsrTaskConfig(pipeBase.PipelineTaskConfig,
     doSuspect = pexConfig.Field(
         dtype=bool,
         doc="Mask suspect pixels?",
-        default=True,
+        default=False,
     )
     suspectMaskName = pexConfig.Field(
         dtype=str,


### PR DESCRIPTION
Set doSuspect=False by default.