### PR TITLE
DM-23023: Simplify linearity corrections

### DIFF
--- a/tests/test_isrMisc.py
+++ b/tests/test_isrMisc.py
@@ -88,7 +88,7 @@ class IsrMiscCases(lsst.utils.tests.TestCase):
         """Assert that the linearize task does not error when a linearity is requested.
         """
         for linearityTypeName in ('LookupTable', 'Squared', 'Unknown'):
-            result = linearize.getLinearityTypeByName(linearityTypeName)
+            result = linearize.Linearizer().getLinearityTypeByName(linearityTypeName)
             # These return the actual class to use, so use Equal instead of IsInstance.
             if linearityTypeName == 'LookupTable':
                 self.assertEqual(result, linearize.LinearizeLookupTable, msg=f"{linearityTypeName}")

--- a/tests/test_isrMisc.py
+++ b/tests/test_isrMisc.py
@@ -87,13 +87,15 @@ class IsrMiscCases(lsst.utils.tests.TestCase):
     def test_linearize(self):
         """Assert that the linearize task does not error when a linearity is requested.
         """
-        for linearityTypeName in ('LookupTable', 'Squared', 'Unknown'):
+        for linearityTypeName in ('LookupTable', 'Squared', 'Polynomial', 'Unknown'):
             result = linearize.Linearizer().getLinearityTypeByName(linearityTypeName)
             # These return the actual class to use, so use Equal instead of IsInstance.
             if linearityTypeName == 'LookupTable':
                 self.assertEqual(result, linearize.LinearizeLookupTable, msg=f"{linearityTypeName}")
             elif linearityTypeName == 'Squared':
                 self.assertEqual(result, linearize.LinearizeSquared, msg=f"{linearityTypeName}")
+            elif linearityTypeName == 'Polynomial':
+                self.assertEqual(result, linearize.LinearizePolynomial, msg=f"{linearityTypeName}")
             else:
                 # DM-19707: ip_isr functionality not fully tested by unit tests
                 self.assertIsNone(result)


### PR DESCRIPTION
Implement RFC-665 changes:
 * allow linearity to be persisted in a yaml file (giving linearity measurement code a target).
 * allow cameraGeom linearity to be overridden.
 * pull all duplicated code into a single Linearizer() class.
 * demote the current linearize functors to operate on an image view
 * Define LinearityType=Proportional as a no-op, and add generic polynomial correction code.