### PR TITLE
DM-23702: IsrTask should use regular Input for raw data

### DIFF
--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -60,7 +60,7 @@ __all__ = ["IsrTask", "IsrTaskConfig", "RunIsrTask", "RunIsrConfig"]
 class IsrTaskConnections(pipeBase.PipelineTaskConnections,
                          dimensions={"instrument", "visit", "detector"},
                          defaultTemplates={}):
-    ccdExposure = cT.PrerequisiteInput(
+    ccdExposure = cT.Input(
         name="raw",
         doc="Input exposure to process.",
         storageClass="Exposure",


### PR DESCRIPTION
Switch gen3 'raw' connection to Input.

This changes the connection from a PrerequisiteInput, allowing raw
datasets to be processed even if unconstrained by a --data-query
argument.  This also removes the constraint that prevents processing
of partial repositories that do not include the full set of
CartesianProduct(registry.exposure, registry.detector).