### PR TITLE
DM-23983: Cannot apply crosstalk in Gen 3 DECam processing

### DIFF
--- a/python/lsst/ip/isr/__init__.py
+++ b/python/lsst/ip/isr/__init__.py
@@ -26,6 +26,7 @@ from .isr import *
 from .version import *
 from .isrFunctions import *
 from .assembleCcdTask import *
+from .calibType import *
 from .isrTask import *
 from .linearize import *
 from .crosstalk import *
@@ -36,4 +37,3 @@ from .straylight import *
 from .measureCrosstalk import *
 from .isrQa import *
 from .isrMock import *
-from .calibType import *

--- a/python/lsst/ip/isr/calibType.py
+++ b/python/lsst/ip/isr/calibType.py
@@ -261,9 +261,10 @@ class IsrCalib(abc.ABC):
         tableList.append(Table.read(filename, hdu=1))
         extNum = 2  # Fits indices start at 1, we've read one already.
         try:
-            newTable = Table.read(filename, hdu=extNum)
-            tableList.append(newTable)
-            extNum += 1
+            with warnings.catch_warnings("error"):
+                newTable = Table.read(filename, hdu=extNum)
+                tableList.append(newTable)
+                extNum += 1
         except Exception:
             pass
 

--- a/python/lsst/ip/isr/calibType.py
+++ b/python/lsst/ip/isr/calibType.py
@@ -142,7 +142,7 @@ class IsrCalib(abc.ABC):
         ----------
         setDate : `bool`, optional
             Ensure the metadata CALIBDATE fields are set to the current datetime.
-        kwargs :
+        kwargs : `dict` or `collections.abc.Mapping`, optional
             Set of key=value pairs to assign to the metadata.
         """
         mdOriginal = self.getMetadata()
@@ -474,7 +474,7 @@ class IsrProvenance(IsrCalib):
         setDate : `bool, optional
             Update the CALIBDATE fields in the metadata to the current
             time. Defaults to False.
-        kwargs :
+        kwargs : `dict` or `collections.abc.Mapping`, optional
             Other keyword parameters to set in the metadata.
         """
         kwargs["DETECTOR"] = self._detectorName

--- a/python/lsst/ip/isr/crosstalk.py
+++ b/python/lsst/ip/isr/crosstalk.py
@@ -23,15 +23,439 @@
 Apply intra-detector crosstalk corrections
 """
 import numpy as np
+from astropy.table import Table
 
 import lsst.afw.math
-import lsst.afw.table
 import lsst.afw.detection
 from lsst.pex.config import Config, Field, ChoiceField, ListField
 from lsst.pipe.base import Task
 
-__all__ = ["CrosstalkConfig", "CrosstalkTask", "subtractCrosstalk", "writeCrosstalkCoeffs",
+from lsst.ip.isr import IsrCalib
+
+
+__all__ = ["CrosstalkCalib", "CrosstalkConfig", "CrosstalkTask",
            "NullCrosstalkTask"]
+
+
+class CrosstalkCalib(IsrCalib):
+    """Calibration of amp-to-amp crosstalk coefficients.
+
+    Parameters
+    ----------
+    detector : `lsst.afw.cameraGeom.Detector`, optional
+        Detector to use to pull coefficients from.
+    log : `lsst.log.Log`, optional
+        Log to write messages to.
+    **kwargs :
+        Parameters to pass to parent constructor.
+    """
+    _OBSTYPE = 'CROSSTALK'
+    _SCHEMA = 'Gen3 Crosstalk'
+    _VERSION = 1.0
+
+    def __init__(self, detector=None, **kwargs):
+        self.hasCrosstalk = False
+        self.nAmp = 0
+        self.crosstalkShape = (self.nAmp, self.nAmp)
+
+        self.coeffs = None
+        self.coeffErr = None
+        self.coeffNum = None
+        self.interChip = None
+
+        super().__init__(**kwargs)
+        self.requiredAttributes.update(['hasCrosstalk', 'nAmp', 'coeffs',
+                                        'coeffErr', 'coeffNum', 'interChip'])
+        if detector:
+            self.fromDetector(detector)
+
+    def updateMetadata(self, setDate=False, **kwargs):
+        """Update calibration metadata.
+
+        This calls the base class's method after ensuring the required
+        calibration keywords will be saved.
+
+        Parameters
+        ----------
+        setDate : `bool`, optional
+            Update the CALIBDATE fields in the metadata to the current
+            time. Defaults to False.
+        kwargs :
+            Other keyword parameters to set in the metadata.
+        """
+        kwargs['DETECTOR'] = self._detectorName
+        kwargs['DETECTOR_SERIAL'] = self._detectorSerial
+        kwargs['HAS_CROSSTALK'] = self.hasCrosstalk
+        kwargs['NAMP'] = self.nAmp
+        self.crosstalkShape = (self.nAmp, self.nAmp)
+        kwargs['CROSSTALK_SHAPE'] = self.crosstalkShape
+
+        super().updateMetadata(setDate=setDate, **kwargs)
+
+    def fromDetector(self, detector, coeffVector=None):
+        """Set calibration parameters from the detector.
+
+        Parameters
+        ----------
+        detector : `lsst.afw.cameraGeom.Detector`
+            Detector to use to set parameters from.
+        coeffVector : `numpy.array`, optional
+            Use the geometry in the detector, but supply the
+            coefficients from elsewhere.
+
+        Returns
+        -------
+        calib : `lsst.ip.isr.CrosstalkCalib`
+            The calibration constructed from the detector.
+        """
+        if detector.hasCrosstalk() or coeffVector:
+            self._detectorName = detector.getName()
+            self._detectorSerial = detector.getSerial()
+
+            self.nAmp = len(detector)
+            self.crosstalkShape = (self.nAmp, self.nAmp)
+
+            if coeffVector is not None:
+                crosstalkCoeffs = coeffVector
+            else:
+                crosstalkCoeffs = detector.getCrosstalk()
+            if len(crosstalkCoeffs) == 1 and crosstalkCoeffs[0] == 0.0:
+                return self
+            self.coeffs = np.array(crosstalkCoeffs).reshape(self.crosstalkShape)
+
+            if self.coeffs.shape != self.crosstalkShape:
+                raise RuntimeError("Crosstalk coefficients do not match detector shape. "
+                                   f"{self.crosstalkShape} {self.nAmp}")
+
+            self.interChip = {}
+            self.hasCrosstalk = True
+            self.updateMetadata()
+        return self
+
+    @classmethod
+    def fromDict(cls, dictionary):
+        """Construct a calibration from a dictionary of properties.
+
+        Must be implemented by the specific calibration subclasses.
+
+        Parameters
+        ----------
+        dictionary : `dict`
+            Dictionary of properties.
+
+        Returns
+        -------
+        calib : `lsst.ip.isr.CalibType`
+            Constructed calibration.
+
+        Raises
+        ------
+        RuntimeError :
+            Raised if the supplied dictionary is for a different
+            calibration.
+        """
+        calib = cls()
+
+        if calib._OBSTYPE != dictionary['metadata']['OBSTYPE']:
+            raise RuntimeError(f"Incorrect crosstalk supplied.  Expected {calib._OBSTYPE}, "
+                               f"found {dictionary['metadata']['OBSTYPE']}")
+
+        calib.setMetadata(dictionary['metadata'])
+        calib._detectorName = dictionary['metadata']['DETECTOR']
+        calib._detectorSerial = dictionary['metadata']['DETECTOR_SERIAL']
+
+        calib.hasCrosstalk = dictionary.get('hasCrosstalk',
+                                            dictionary['metadata'].get('HAS_CROSSTALK', False))
+        if calib.hasCrosstalk:
+            calib.nAmp = dictionary.get('nAmp', dictionary['metadata'].get('NAMP', 0))
+            calib.crosstalkShape = (calib.nAmp, calib.nAmp)
+            calib.coeffs = np.array(dictionary['coeffs']).reshape(calib.crosstalkShape)
+
+            calib.interChip = dictionary.get('interChip', None)
+            if calib.interChip:
+                for detector in calib.interChip:
+                    coeffVector = calib.interChip[detector]
+                    calib.interChip[detector] = np.array(coeffVector).reshape(calib.crosstalkShape)
+
+        calib.updateMetadata()
+        return calib
+
+    def toDict(self):
+        """Return a dictionary containing the calibration properties.
+
+        The dictionary should be able to be round-tripped through
+        `fromDict`.
+
+        Returns
+        -------
+        dictionary : `dict`
+            Dictionary of properties.
+        """
+        self.updateMetadata(setDate=True)
+
+        outDict = {}
+        metadata = self.getMetadata()
+        outDict['metadata'] = metadata
+
+        outDict['hasCrosstalk'] = self.hasCrosstalk
+        outDict['nAmp'] = self.nAmp
+        outDict['crosstalkShape'] = self.crosstalkShape
+
+        ctLength = self.nAmp*self.nAmp
+        outDict['coeffs'] = self.coeffs.reshape(ctLength).tolist()
+
+        if self.coeffErr is not None:
+            outDict['coeffErr'] = self.coeffErr.reshape(ctLength).tolist()
+        if self.coeffNum is not None:
+            outDict['coeffNum'] = self.coeffNum.reshape(ctLength).tolist()
+
+        if self.interChip:
+            outDict['interChip'] = dict()
+            for detector in self.interChip:
+                outDict['interChip'][detector] = self.interChip[detector].reshape(ctLength).tolist()
+
+        return outDict
+
+    @classmethod
+    def fromTable(cls, tableList):
+        """Construct calibration from a list of tables.
+
+        This method uses the `fromDict` method to create the
+        calibration, after constructing an appropriate dictionary from
+        the input tables.
+
+        Parameters
+        ----------
+        tableList : `list` [`lsst.afw.table.Table`]
+            List of tables to use to construct the crosstalk
+            calibration.
+
+        Returns
+        -------
+        calib : `lsst.ip.isr.CrosstalkCalib`
+            The calibration defined in the tables.
+
+        """
+        coeffTable = tableList[0]
+
+        metadata = coeffTable.meta
+        inDict = dict()
+        inDict['metadata'] = metadata
+        inDict['hasCrosstalk'] = metadata['HAS_CROSSTALK']
+        inDict['nAmp'] = metadata['NAMP']
+
+        inDict['coeffs'] = coeffTable['CT_COEFFS']
+        if len(tableList) > 1:
+            inDict['interChip'] = dict()
+            interChipTable = tableList[1]
+            for record in interChipTable:
+                inDict['interChip'][record['IC_SOURCE_DET']] = record['IC_COEFFS']
+
+        return cls().fromDict(inDict)
+
+    def toTable(self):
+        """Construct a list of tables containing the information in this calibration.
+
+        The list of tables should create an identical calibration
+        after being passed to this class's fromTable method.
+
+        Returns
+        -------
+        tableList : `list` [`lsst.afw.table.Table`]
+            List of tables containing the crosstalk calibration
+            information.
+
+        """
+        tableList = []
+        self.updateMetadata(setDate=True)
+        catalog = Table([{'CT_COEFFS': self.coeffs.reshape(self.nAmp*self.nAmp)}])
+        catalog.meta = self.getMetadata().toDict()
+        tableList.append(catalog)
+
+        if self.interChip:
+            interChipTable = Table([{'IC_SOURCE_DET': sourceDet,
+                                     'IC_COEFFS': self.interChip[sourceDet].reshape(self.nAmp*self.nAmp)}
+                                    for sourceDet in self.interChip.keys()])
+            tableList.append(interChipTable)
+        return tableList
+
+    # Implementation methods.
+    def extractAmp(self, image, amp, ampTarget, isTrimmed=False):
+
+        """Extract the image data from an amp, flipped to match ampTarget.
+
+        Parameters
+        ----------
+        image : `lsst.afw.image.Image` or `lsst.afw.image.MaskedImage`
+            Image containing the amplifier of interest.
+        amp : `lsst.afw.cameraGeom.Amplifier`
+            Amplifier on image to extract.
+        ampTarget : `lsst.afw.cameraGeom.Amplifier`
+            Target amplifier that the extracted image will be flipped
+            to match.
+        isTrimmed : `bool`
+            The image is already trimmed.
+            This should no longer be needed once DM-15409 is resolved.
+
+        Returns
+        -------
+        output : `lsst.afw.image.Image`
+            Image of the amplifier in the desired configuration.
+        """
+        X_FLIP = {lsst.afw.cameraGeom.ReadoutCorner.LL: False,
+                  lsst.afw.cameraGeom.ReadoutCorner.LR: True,
+                  lsst.afw.cameraGeom.ReadoutCorner.UL: False,
+                  lsst.afw.cameraGeom.ReadoutCorner.UR: True}
+        Y_FLIP = {lsst.afw.cameraGeom.ReadoutCorner.LL: False,
+                  lsst.afw.cameraGeom.ReadoutCorner.LR: False,
+                  lsst.afw.cameraGeom.ReadoutCorner.UL: True,
+                  lsst.afw.cameraGeom.ReadoutCorner.UR: True}
+
+        output = image[amp.getBBox() if isTrimmed else amp.getRawDataBBox()]
+        thisAmpCorner = amp.getReadoutCorner()
+        targetAmpCorner = ampTarget.getReadoutCorner()
+
+        # Flipping is necessary only if the desired configuration doesn't match what we currently have
+        xFlip = X_FLIP[targetAmpCorner] ^ X_FLIP[thisAmpCorner]
+        yFlip = Y_FLIP[targetAmpCorner] ^ Y_FLIP[thisAmpCorner]
+        self.log.debug("Extract amp: %s %s %s %s",
+                       amp.getName(), ampTarget.getName(), thisAmpCorner, targetAmpCorner)
+        return lsst.afw.math.flipImage(output, xFlip, yFlip)
+
+    def calculateBackground(self, mi, badPixels=["BAD"]):
+        """Calculate median background in image
+
+        Getting a great background model isn't important for crosstalk correction,
+        since the crosstalk is at a low level. The median should be sufficient.
+
+        Parameters
+        ----------
+        mi : `lsst.afw.image.MaskedImage`
+            MaskedImage for which to measure background.
+        badPixels : `list` of `str`
+            Mask planes to ignore.
+        Returns
+        -------
+        bg : `float`
+            Median background level.
+        """
+        mask = mi.getMask()
+        stats = lsst.afw.math.StatisticsControl()
+        stats.setAndMask(mask.getPlaneBitMask(badPixels))
+        return lsst.afw.math.makeStatistics(mi, lsst.afw.math.MEDIAN, stats).getValue()
+
+    def subtractCrosstalk(self, thisExposure, sourceExposure=None, crosstalkCoeffs=None,
+                          badPixels=["BAD"], minPixelToMask=45000,
+                          crosstalkStr="CROSSTALK", isTrimmed=False,
+                          backgroundMethod="None"):
+        """Subtract the crosstalk from thisExposure, optionally using a different source.
+
+        We set the mask plane indicated by ``crosstalkStr`` in a target amplifier
+        for pixels in a source amplifier that exceed `minPixelToMask`. Note that
+        the correction is applied to all pixels in the amplifier, but only those
+        that have a substantial crosstalk are masked with ``crosstalkStr``.
+
+        The uncorrected image is used as a template for correction. This is good
+        enough if the crosstalk is small (e.g., coefficients < ~ 1e-3), but if it's
+        larger you may want to iterate.
+
+        This method needs unittests (DM-18876), but such testing requires
+        DM-18610 to allow the test detector to have the crosstalk
+        parameters set.
+
+        Parameters
+        ----------
+        thisExposure : `lsst.afw.image.Exposure`
+            Exposure for which to subtract crosstalk.
+        sourceExposure : `lsst.afw.image.Exposure`, optional
+            Exposure to use as the source of the crosstalk.  If not set,
+            thisExposure is used as the source (intra-detector crosstalk).
+        crosstalkCoeffs : `numpy.ndarray`, optional.
+            Coefficients to use to correct crosstalk.
+        badPixels : `list` of `str`
+            Mask planes to ignore.
+        minPixelToMask : `float`
+            Minimum pixel value (relative to the background level) in
+            source amplifier for which to set ``crosstalkStr`` mask plane
+            in target amplifier.
+        crosstalkStr : `str`
+            Mask plane name for pixels greatly modified by crosstalk
+            (above minPixelToMask).
+        isTrimmed : `bool`
+            The image is already trimmed.
+            This should no longer be needed once DM-15409 is resolved.
+        backgroundMethod : `str`
+            Method used to subtract the background.  "AMP" uses
+            amplifier-by-amplifier background levels, "DETECTOR" uses full
+            exposure/maskedImage levels.  Any other value results in no
+            background subtraction.
+        """
+        mi = thisExposure.getMaskedImage()
+        mask = mi.getMask()
+        detector = thisExposure.getDetector()
+        if self.hasCrosstalk is False:
+            self.fromDetector(detector, coeffVector=crosstalkCoeffs)
+
+        numAmps = len(detector)
+        if numAmps != self.nAmp:
+            raise RuntimeError(f"Crosstalk built for {self.nAmp} in {self._detectorName}, received "
+                               f"{numAmps} in {detector.getName()}")
+
+        if sourceExposure:
+            source = sourceExposure.getMaskedImage()
+            sourceDetector = sourceExposure.getDetector()
+        else:
+            source = mi
+            sourceDetector = detector
+
+        if crosstalkCoeffs is not None:
+            coeffs = crosstalkCoeffs
+        else:
+            coeffs = self.coeffs
+        self.log.debug("CT COEFF: %s", coeffs)
+        # Set background level based on the requested method.  The
+        # thresholdBackground holds the offset needed so that we only mask
+        # pixels high relative to the background, not in an absolute
+        # sense.
+        thresholdBackground = self.calculateBackground(source, badPixels)
+
+        backgrounds = [0.0 for amp in sourceDetector]
+        if backgroundMethod is None:
+            pass
+        elif backgroundMethod == "AMP":
+            backgrounds = [self.calculateBackground(source[amp.getBBox()], badPixels)
+                           for amp in sourceDetector]
+        elif backgroundMethod == "DETECTOR":
+            backgrounds = [self.calculateBackground(source, badPixels) for amp in sourceDetector]
+
+        # Set the crosstalkStr bit for the bright pixels (those which will have
+        # significant crosstalk correction)
+        crosstalkPlane = mask.addMaskPlane(crosstalkStr)
+        footprints = lsst.afw.detection.FootprintSet(source,
+                                                     lsst.afw.detection.Threshold(minPixelToMask +
+                                                                                  thresholdBackground))
+        footprints.setMask(mask, crosstalkStr)
+        crosstalk = mask.getPlaneBitMask(crosstalkStr)
+
+        # Define a subtrahend image to contain all the scaled crosstalk signals
+        subtrahend = source.Factory(source.getBBox())
+        subtrahend.set((0, 0, 0))
+
+        coeffs = coeffs.transpose()
+        for ii, iAmp in enumerate(sourceDetector):
+            iImage = subtrahend[iAmp.getBBox() if isTrimmed else iAmp.getRawDataBBox()]
+            for jj, jAmp in enumerate(detector):
+                if coeffs[ii, jj] == 0.0:
+                    continue
+                jImage = self.extractAmp(mi, jAmp, iAmp, isTrimmed)
+                jImage.getMask().getArray()[:] &= crosstalk  # Remove all other masks
+                jImage -= backgrounds[jj]
+                iImage.scaledPlus(coeffs[ii, jj], jImage)
+
+        # Set crosstalkStr bit only for those pixels that have been significantly modified (i.e., those
+        # masked as such in 'subtrahend'), not necessarily those that are bright originally.
+        mask.clearMaskPlane(crosstalkPlane)
+        mi -= subtrahend  # also sets crosstalkStr bit for bright pixels
 
 
 class CrosstalkConfig(Config):
@@ -133,13 +557,15 @@ class CrosstalkTask(Task):
     ConfigClass = CrosstalkConfig
     _DefaultName = 'isrCrosstalk'
 
-    def prepCrosstalk(self, dataRef):
+    def prepCrosstalk(self, dataRef, crosstalk=None):
         """Placeholder for crosstalk preparation method, e.g., for inter-detector crosstalk.
 
         Parameters
         ----------
         dataRef : `daf.persistence.butlerSubset.ButlerDataRef`
             Butler reference of the detector data to be processed.
+        crosstalk : `~lsst.ip.isr.CrosstalkConfig`
+            Crosstalk calibration that will be used.
 
         See also
         --------
@@ -147,16 +573,23 @@ class CrosstalkTask(Task):
         """
         return
 
-    def run(self, exposure, crosstalkSources=None, isTrimmed=False):
+    def run(self, exposure, crosstalk=None,
+            crosstalkSources=None, isTrimmed=False):
         """Apply intra-detector crosstalk correction
 
         Parameters
         ----------
         exposure : `lsst.afw.image.Exposure`
             Exposure for which to remove crosstalk.
+        crosstalkCalib : `lsst.ip.isr.CrosstalkCalib`, optional
+            External crosstalk calibration to apply.  Constructed from
+            detector if not found.
         crosstalkSources : `defaultdict`, optional
-            Image data and crosstalk coefficients from other detectors/amps that are
-            sources of crosstalk in exposure.
+            Image data for other detectors that are sources of
+            crosstalk in exposure.  The keys are expected to be names
+            of the other detectors, with the values containing
+            `lsst.afw.image.Exposure` at the same level of processing
+            as ``exposure``.
             The default for intra-detector crosstalk here is None.
         isTrimmed : `bool`
             The image is already trimmed.
@@ -167,255 +600,53 @@ class CrosstalkTask(Task):
         RuntimeError
             Raised if called for a detector that does not have a
             crosstalk correction.
-        TypeError
-            Raised if crosstalkSources is not None
-            and not a numpy array or a dictionary.
         """
-        if crosstalkSources is not None:
-            if isinstance(crosstalkSources, np.ndarray):
-                coeffs = crosstalkSources
-            elif isinstance(crosstalkSources, dict):
-                # Nested dictionary produced by `measureCrosstalk.py`
-                # There are two keys first in the nested dictionary
-                for fKey, fValue in crosstalkSources.items():
-                    for sKey, sValue in fValue.items():
-                        firstKey = fKey
-                        secondKey = sKey
-                tempDict = crosstalkSources[firstKey][secondKey]
-                coeffs = []
-                for thirdKey in tempDict:
-                    tempList = []
-                    for fourthKey in tempDict[thirdKey]:
-                        value = tempDict[thirdKey][fourthKey]
-                        tempList.append(value)
-                    coeffs.append(tempList)
-                coeffs = np.array(coeffs)
-            else:
-                raise TypeError("crosstalkSources not of the correct type: `np.array` or `dict`")
+        if not crosstalk:
+            crosstalk = CrosstalkCalib(log=self.log)
+            crosstalk = crosstalk.fromDetector(exposure.getDetector(),
+                                               coeffVector=self.config.crosstalkValues)
+            # detector = exposure.getDetector()
+            # if not self.config.hasCrosstalk(detector=detector):
+            # raise RuntimeError("Attempted to correct crosstalk without crosstalk coefficients")
+            # coeffs = self.config.getCrosstalk(detector=detector)
+        if not crosstalk.log:
+            crosstalk.log = self.log
+        if not crosstalk.hasCrosstalk:
+            raise RuntimeError("Attempted to correct crosstalk without crosstalk coefficients.")
+            self.log.warn("Attempted to correct crosstalk without crosstalk coefficients.")
         else:
-            detector = exposure.getDetector()
-            if not self.config.hasCrosstalk(detector=detector):
-                raise RuntimeError("Attempted to correct crosstalk without crosstalk coefficients")
-            coeffs = self.config.getCrosstalk(detector=detector)
+            self.log.info("Applying crosstalk correction.")
+            crosstalk.subtractCrosstalk(exposure, crosstalkCoeffs=crosstalk.coeffs,
+                                        minPixelToMask=self.config.minPixelToMask,
+                                        crosstalkStr=self.config.crosstalkMaskPlane, isTrimmed=isTrimmed,
+                                        backgroundMethod=self.config.crosstalkBackgroundMethod)
 
-        self.log.info("Applying crosstalk correction.")
-        subtractCrosstalk(exposure, crosstalkCoeffs=coeffs,
-                          minPixelToMask=self.config.minPixelToMask,
-                          crosstalkStr=self.config.crosstalkMaskPlane, isTrimmed=isTrimmed,
-                          backgroundMethod=self.config.crosstalkBackgroundMethod)
-
-
-# Flips required to get the corner to the lower-left
-# (an arbitrary choice; flips are relative, so the choice of reference here is not important)
-X_FLIP = {lsst.afw.cameraGeom.ReadoutCorner.LL: False, lsst.afw.cameraGeom.ReadoutCorner.LR: True,
-          lsst.afw.cameraGeom.ReadoutCorner.UL: False, lsst.afw.cameraGeom.ReadoutCorner.UR: True}
-Y_FLIP = {lsst.afw.cameraGeom.ReadoutCorner.LL: False, lsst.afw.cameraGeom.ReadoutCorner.LR: False,
-          lsst.afw.cameraGeom.ReadoutCorner.UL: True, lsst.afw.cameraGeom.ReadoutCorner.UR: True}
+            if crosstalk.interChip:
+                if crosstalkSources:
+                    for detName in crosstalk.interChip:
+                        if isinstance(crosstalkSources[0], 'lsst.afw.image.Exposure'):
+                            # Received a proper exposure
+                            sourceNames = [exp.getDetector().getName() for exp in crosstalkSources]
+                        else:
+                            # Received deferred dataset
+                            sourceNames = [expRef.get(datasetType='isrOscanCorr').getDetector().getName()
+                                           for expRef in crosstalkSources]
+                        if detName not in sourceNames:
+                            self.log.warn("Crosstalk lists %s, not found in sources: %s",
+                                          detName, sourceNames)
+                            continue
+                        interChipCoeffs = crosstalk.interChip[detName]
+                        sourceExposure = crosstalkSources[sourceNames.index(detName)]
+                        crosstalk.subtractCrosstalk(exposure, sourceExposure=sourceExposure,
+                                                    crosstalkCoeffs=interChipCoeffs,
+                                                    minPixelToMask=self.config.minPixelToMask,
+                                                    crosstalkStr=self.config.crosstalkMaskPlane,
+                                                    isTrimmed=isTrimmed,
+                                                    backgroundMethod=self.config.crosstalkBackgroundMethod)
+                else:
+                    self.log.warn(f"Crosstalk contains interChip coefficients, but no sources found!")
 
 
 class NullCrosstalkTask(CrosstalkTask):
     def run(self, exposure, crosstalkSources=None):
         self.log.info("Not performing any crosstalk correction")
-
-
-def extractAmp(image, amp, corner, isTrimmed=False):
-    """Return an image of the amp
-
-    The returned image will have the amp's readout corner in the
-    nominated `corner`.
-
-    Parameters
-    ----------
-    image : `lsst.afw.image.Image` or `lsst.afw.image.MaskedImage`
-        Image containing the amplifier of interest.
-    amp : `lsst.afw.table.AmpInfoRecord`
-        Amplifier information.
-    corner : `lsst.afw.table.ReadoutCorner` or `None`
-        Corner in which to put the amp's readout corner, or `None` for
-        no flipping.
-    isTrimmed : `bool`
-        The image is already trimmed.
-        This should no longer be needed once DM-15409 is resolved.
-
-    Returns
-    -------
-    output : `lsst.afw.image.Image`
-        Image of the amplifier in the standard configuration.
-    """
-    output = image[amp.getBBox() if isTrimmed else amp.getRawDataBBox()]
-    ampCorner = amp.getReadoutCorner()
-    # Flipping is necessary only if the desired configuration doesn't match what we currently have
-    xFlip = X_FLIP[corner] ^ X_FLIP[ampCorner]
-    yFlip = Y_FLIP[corner] ^ Y_FLIP[ampCorner]
-    return lsst.afw.math.flipImage(output, xFlip, yFlip)
-
-
-def calculateBackground(mi, badPixels=["BAD"]):
-    """Calculate median background in image
-
-    Getting a great background model isn't important for crosstalk correction,
-    since the crosstalk is at a low level. The median should be sufficient.
-
-    Parameters
-    ----------
-    mi : `lsst.afw.image.MaskedImage`
-        MaskedImage for which to measure background.
-    badPixels : `list` of `str`
-        Mask planes to ignore.
-
-    Returns
-    -------
-    bg : `float`
-        Median background level.
-    """
-    mask = mi.getMask()
-    stats = lsst.afw.math.StatisticsControl()
-    stats.setAndMask(mask.getPlaneBitMask(badPixels))
-    return lsst.afw.math.makeStatistics(mi, lsst.afw.math.MEDIAN, stats).getValue()
-
-
-def subtractCrosstalk(exposure, crosstalkCoeffs=None,
-                      badPixels=["BAD"], minPixelToMask=45000,
-                      crosstalkStr="CROSSTALK", isTrimmed=False,
-                      backgroundMethod="None"):
-    """Subtract the intra-detector crosstalk from an exposure
-
-    We set the mask plane indicated by ``crosstalkStr`` in a target amplifier
-    for pixels in a source amplifier that exceed `minPixelToMask`. Note that
-    the correction is applied to all pixels in the amplifier, but only those
-    that have a substantial crosstalk are masked with ``crosstalkStr``.
-
-    The uncorrected image is used as a template for correction. This is good
-    enough if the crosstalk is small (e.g., coefficients < ~ 1e-3), but if it's
-    larger you may want to iterate.
-
-    This method needs unittests (DM-18876), but such testing requires
-    DM-18610 to allow the test detector to have the crosstalk
-    parameters set.
-
-    Parameters
-    ----------
-    exposure : `lsst.afw.image.Exposure`
-        Exposure for which to subtract crosstalk.
-    crosstalkCoeffs : `numpy.ndarray`
-        Coefficients to use to correct crosstalk.
-    badPixels : `list` of `str`
-        Mask planes to ignore.
-    minPixelToMask : `float`
-        Minimum pixel value (relative to the background level) in
-        source amplifier for which to set ``crosstalkStr`` mask plane
-        in target amplifier.
-    crosstalkStr : `str`
-        Mask plane name for pixels greatly modified by crosstalk.
-    isTrimmed : `bool`
-        The image is already trimmed.
-        This should no longer be needed once DM-15409 is resolved.
-    backgroundMethod : `str`
-        Method used to subtract the background.  "AMP" uses
-        amplifier-by-amplifier background levels, "DETECTOR" uses full
-        exposure/maskedImage levels.  Any other value results in no
-        background subtraction.
-    """
-    mi = exposure.getMaskedImage()
-    mask = mi.getMask()
-
-    ccd = exposure.getDetector()
-    numAmps = len(ccd)
-    if crosstalkCoeffs is None:
-        coeffs = ccd.getCrosstalk()
-    else:
-        coeffs = crosstalkCoeffs
-    assert coeffs.shape == (numAmps, numAmps)
-
-    # Set background level based on the requested method.  The
-    # thresholdBackground holds the offset needed so that we only mask
-    # pixels high relative to the background, not in an absolute
-    # sense.
-    thresholdBackground = calculateBackground(mi, badPixels)
-
-    backgrounds = [0.0 for amp in ccd]
-    if backgroundMethod is None:
-        pass
-    elif backgroundMethod == "AMP":
-        backgrounds = [calculateBackground(mi[amp.getBBox()], badPixels) for amp in ccd]
-    elif backgroundMethod == "DETECTOR":
-        backgrounds = [calculateBackground(mi, badPixels) for amp in ccd]
-
-    # Set the crosstalkStr bit for the bright pixels (those which will have significant crosstalk correction)
-    crosstalkPlane = mask.addMaskPlane(crosstalkStr)
-    footprints = lsst.afw.detection.FootprintSet(mi, lsst.afw.detection.Threshold(minPixelToMask +
-                                                                                  thresholdBackground))
-    footprints.setMask(mask, crosstalkStr)
-    crosstalk = mask.getPlaneBitMask(crosstalkStr)
-
-    # Do pixel level crosstalk correction.
-    subtrahend = mi.Factory(mi.getBBox())
-    subtrahend.set((0, 0, 0))
-    for ii, iAmp in enumerate(ccd):
-        iImage = subtrahend[iAmp.getBBox() if isTrimmed else iAmp.getRawDataBBox()]
-        for jj, jAmp in enumerate(ccd):
-            if ii == jj:
-                assert coeffs[ii, jj] == 0.0
-            if coeffs[ii, jj] == 0.0:
-                continue
-
-            jImage = extractAmp(mi, jAmp, iAmp.getReadoutCorner(), isTrimmed)
-            jImage.getMask().getArray()[:] &= crosstalk  # Remove all other masks
-            jImage -= backgrounds[jj]
-
-            iImage.scaledPlus(coeffs[ii, jj], jImage)
-
-    # Set crosstalkStr bit only for those pixels that have been significantly modified (i.e., those
-    # masked as such in 'subtrahend'), not necessarily those that are bright originally.
-    mask.clearMaskPlane(crosstalkPlane)
-    mi -= subtrahend  # also sets crosstalkStr bit for bright pixels
-
-
-def writeCrosstalkCoeffs(outputFileName, coeff, det=None, crosstalkName="Unknown", indent=2):
-    """Write a yaml file containing the crosstalk coefficients
-
-    The coeff array is indexed by [i, j] where i and j are amplifiers
-    corresponding to the amplifiers in det
-
-    Parameters
-    ----------
-    outputFileName : `str`
-        Name of output yaml file
-    coeff : `numpy.array(namp, namp)`
-        numpy array of coefficients
-    det : `lsst.afw.cameraGeom.Detector`
-        Used to provide the list of amplifier names;
-        if None use ['0', '1', ...]
-    ccdType : `str`
-        Name of detector, used to index the yaml file
-        If all detectors are identical could be the type (e.g. ITL)
-    indent : `int`
-        Indent width to use when writing the yaml file
-    """
-
-    if det is None:
-        ampNames = [str(i) for i in range(coeff.shape[0])]
-    else:
-        ampNames = [a.getName() for a in det]
-
-    assert coeff.shape == (len(ampNames), len(ampNames))
-
-    dIndent = indent
-    indent = 0
-    with open(outputFileName, "w") as fd:
-        print(indent*" " + "crosstalk :", file=fd)
-        indent += dIndent
-        print(indent*" " + "%s :" % crosstalkName, file=fd)
-        indent += dIndent
-
-        for i, ampNameI in enumerate(ampNames):
-            print(indent*" " + "%s : {" % ampNameI, file=fd)
-            indent += dIndent
-            print(indent*" ", file=fd, end='')
-
-            for j, ampNameJ in enumerate(ampNames):
-                print("%s : %11.4e, " % (ampNameJ, coeff[i, j]), file=fd,
-                      end='\n' + indent*" " if j%4 == 3 else '')
-            print("}", file=fd)
-
-            indent -= dIndent

--- a/python/lsst/ip/isr/crosstalk.py
+++ b/python/lsst/ip/isr/crosstalk.py
@@ -191,7 +191,7 @@ class CrosstalkCalib(IsrCalib):
         dictionary : `dict`
             Dictionary of properties.
         """
-        self.updateMetadata(setDate=True)
+        self.updateMetadata()
 
         outDict = {}
         metadata = self.getMetadata()
@@ -267,7 +267,7 @@ class CrosstalkCalib(IsrCalib):
 
         """
         tableList = []
-        self.updateMetadata(setDate=True)
+        self.updateMetadata()
         catalog = Table([{'CT_COEFFS': self.coeffs.reshape(self.nAmp*self.nAmp)}])
         catalog.meta = self.getMetadata().toDict()
         tableList.append(catalog)

--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -66,6 +66,9 @@ def crosstalkSourceLookup(datasetType, registry, quantumDataId, collections):
     when inter-chip crosstalk has been identified should this be
     populated.
 
+    This will be unused until DM-25348 resolves the quantum graph
+    generation issue.
+
     Parameters
     ----------
     datasetType : `str`
@@ -117,8 +120,10 @@ class IsrTaskConnections(pipeBase.PipelineTaskConnections,
         storageClass="CrosstalkCalib",
         dimensions=["instrument", "calibration_label", "detector"],
     )
+    # TODO: DM-25348.  This does not work yet to correctly load
+    # possible crosstalk sources.
     crosstalkSources = cT.PrerequisiteInput(
-        name="CTisrOscanCorr",
+        name="isrOverscanCorrected",
         doc="Overscan corrected input images.",
         storageClass="Exposure",
         dimensions=["instrument", "exposure", "detector"],

--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -59,7 +59,7 @@ from lsst.daf.butler import DataCoordinate, DimensionGraph, DimensionUniverse
 __all__ = ["IsrTask", "IsrTaskConfig", "RunIsrTask", "RunIsrConfig"]
 
 
-def crosstalkSourceLUF(datasetType, registry, quantumDataId, collections):
+def crosstalkSourceLookup(datasetType, registry, quantumDataId, collections):
     """Lookup function to identify crosstalkSource entries.
 
     This should return an empty list under most circumstances.  Only
@@ -124,7 +124,7 @@ class IsrTaskConnections(pipeBase.PipelineTaskConnections,
         dimensions=["instrument", "exposure", "detector"],
         deferLoad=True,
         multiple=True,
-        lookupFunction=crosstalkSourceLUF,
+        lookupFunction=crosstalkSourceLookup,
     )
     bias = cT.PrerequisiteInput(
         name="bias",
@@ -901,6 +901,9 @@ class IsrTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
                                if self.config.crosstalk.useConfigCoefficients else None)
                 crosstalkCalib = CrosstalkCalib().fromDetector(detector, coeffVector=coeffVector)
                 inputs['crosstalk'] = crosstalkCalib
+            if inputs['crosstalk'].interChip and len(inputs['crosstalk'].interChip) > 0:
+                if 'crosstalkSources' not in inputs:
+                    self.log.warn("No crosstalkSources found for chip with interChip terms!")
 
         if self.doLinearize(detector) is True:
             if 'linearizer' in inputs and isinstance(inputs['linearizer'], dict):

--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -62,8 +62,8 @@ __all__ = ["IsrTask", "IsrTaskConfig", "RunIsrTask", "RunIsrConfig"]
 def ctSourceLUF(datasetType, registry, quantumDataId, collections):
 
     newDataId = DataCoordinate(DimensionGraph(DimensionUniverse(),
-                                              names=('instrument', 'visit')),
-                               (quantumDataId['instrument'], quantumDataId['visit']))
+                                              names=('instrument', 'exposure')),
+                               (quantumDataId['instrument'], quantumDataId['exposure']))
     results = list(registry.queryDatasets(datasetType,
                                           collections=collections,
                                           dataId=newDataId,
@@ -82,7 +82,7 @@ class IsrTaskConnections(pipeBase.PipelineTaskConnections,
         name="raw",
         doc="Input exposure to process.",
         storageClass="Exposure",
-        dimensions=["instrument", "detector", "exposure"],
+        dimensions=["instrument", "exposure", "detector"],
     )
     camera = cT.PrerequisiteInput(
         name="camera",
@@ -101,7 +101,7 @@ class IsrTaskConnections(pipeBase.PipelineTaskConnections,
         name="CTisrOscanCorr",
         doc="Overscan corrected input images.",
         storageClass="Exposure",
-        dimensions=["instrument", "visit", "exposure", "detector"],
+        dimensions=["instrument", "exposure", "detector"],
         deferLoad=True,
         multiple=True,
         lookupFunction=ctSourceLUF,

--- a/python/lsst/ip/isr/measureCrosstalk.py
+++ b/python/lsst/ip/isr/measureCrosstalk.py
@@ -147,7 +147,13 @@ class MeasureCrosstalkTask(CmdLineTask):
 
     @classmethod
     def parseAndRun(cls, *args, **kwargs):
-        """Implement scatter/gather
+        """Collate crosstalk results from multiple exposures.
+
+        Process all input exposures through runDataRef, construct
+        final measurements from the final list of results from each
+        input, and persist the output calibration.
+
+        This method will be deprecated as part of DM-24760.
 
         Returns
         -------
@@ -157,6 +163,9 @@ class MeasureCrosstalkTask(CmdLineTask):
             Crosstalk coefficient errors.
         coeffNum : `numpy.ndarray`
             Number of pixels used for crosstalk measurement.
+        calib : `lsst.ip.isr.CrosstalkCalib`
+            Crosstalk object created from the measurements.
+
         """
         kwargs["doReturnResults"] = True
         results = super(MeasureCrosstalkTask, cls).parseAndRun(*args, **kwargs)
@@ -179,7 +188,7 @@ class MeasureCrosstalkTask(CmdLineTask):
             butler = results.parsedCmd.butler
             dataId = results.parsedCmd.id.idList[0]
 
-            # Rework to use new crosstalk calib.
+            # Rework to use lsst.ip.isr.CrosstalkCalib.
             det = butler.get('raw', dataId).getDetector()
             calib._detectorName = det.getName()
             calib._detectorSerial = det.getSerial()


### PR DESCRIPTION
Implement CrosstalkCalib class inheriting from IsrCalib. 

Add inter-chip crosstalk handling.
Switch to Exposure (no F) as the output product in gen3 to allow IsrTask to process an input in multiple passes.