### PR TITLE
DM-26316: Allow bias generation to retain overscan signal

### DIFF
--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -847,6 +847,8 @@ class IsrTaskConfig(pipeBase.PipelineTaskConfig,
         super().validate()
         if self.doFlat and self.doApplyGains:
             raise ValueError("You may not specify both doFlat and doApplyGains")
+        if self.doBiasBeforeOverscan and self.doTrimToMatchCalib:
+            raise ValueError("You may not specify both doBiasBeforeOverscan and doTrimToMatchCalib")
         if self.doSaturationInterpolation and "SAT" not in self.maskListToInterpolate:
             self.config.maskListToInterpolate.append("SAT")
         if self.doNanInterpolation and "UNMASKEDNAN" not in self.maskListToInterpolate:


### PR DESCRIPTION
Add option to reverse Bias and Overscan correction ordering.