### PR TITLE
DM-26452: Fix fringe filter inconsistency

### DIFF
--- a/python/lsst/ip/isr/fringe.py
+++ b/python/lsst/ip/isr/fringe.py
@@ -248,7 +248,9 @@ class FringeTask(Task):
             If True, then the exposure has a filter listed in the
             configuration, and should have the fringe applied.
         """
-        return exposure.getFilter().getName() in self.config.filters
+        # Canonical name for filter
+        filterName = afwImage.Filter(exposure.getFilter().getId()).getName()
+        return filterName in self.config.filters
 
     def removePedestal(self, fringe):
         """Remove pedestal from fringe exposure.


### PR DESCRIPTION
Use the same filter name determination in all places that the fringe is checked.
Add fringe support for matching against filter name aliases.