### PR TITLE
DM-26414: Handle masked pixels in ip_isr's MEDIAN_PER_ROW

### DIFF
--- a/python/lsst/ip/isr/overscan.py
+++ b/python/lsst/ip/isr/overscan.py
@@ -341,7 +341,8 @@ class OverscanCorrectionTask(pipeBase.Task):
         collapsed = []
         fitType = afwMath.stringToStatisticsProperty('MEDIAN')
         for row in integerMI:
-            rowMedian = afwMath.makeStatistics(row, fitType, self.statControl).getValue()
+            newRow = row.compressed()
+            rowMedian = afwMath.makeStatistics(newRow, fitType, self.statControl).getValue()
             collapsed.append(rowMedian)
 
         return np.array(collapsed)


### PR DESCRIPTION
Avoid unnecessary warnings in overscan.

Remove masked points to avoid the afwMath.makeStatistics() warning
that occurs with those points.

Add unit test to ensure outlier masking functions correctly.