### PR TITLE
DM-24703: Make linearity a subclass of lsst.ip.isr.IsrCalib

### DIFF
--- a/python/lsst/ip/isr/calibType.py
+++ b/python/lsst/ip/isr/calibType.py
@@ -181,19 +181,11 @@ class IsrCalib(abc.ABC):
 
         if setCalibId:
             values = []
-<<<<<<< HEAD
             values.append(f"instrument={self._instrument}") if self._instrument else None
             values.append(f"raftName={self._raftName}") if self._raftName else None
             values.append(f"detectorName={self._detectorName}") if self._detectorName else None
             values.append(f"detector={self.detector}") if self._detector else None
             values.append(f"filter={self._filter}") if self._filter else None
-=======
-            values.append(f"instrument={self._instrument}") if self._instrument
-            values.append(f"raftName={self._raftName}") if self._raftName
-            values.append(f"detectorName={self._detectorName}") if self._detectorName
-            values.append(f"detector={self.detector}") if self._detector
-            values.append(f"filter={self._filter}") if self._filter
->>>>>>> 52261ee... Handle metadata fields consistently.
             self._calibId = " ".join(values)
 
         if setDate:
@@ -202,7 +194,6 @@ class IsrCalib(abc.ABC):
             mdSupplemental['CALIB_CREATION_DATE'] = date.date().isoformat()
             mdSupplemental['CALIB_CREATION_TIME'] = date.time().isoformat()
 
-<<<<<<< HEAD
         self._metadata["INSTRUME"] = self._instrument if self._instrument else None
         self._metadata["RAFTNAME"] = self._raftName if self._raftName else None
         self._metadata["SLOTNAME"] = self._slotName if self._slotName else None
@@ -211,16 +202,6 @@ class IsrCalib(abc.ABC):
         self._metadata["DET_SER"] = self._detectorSerial if self._detectorSerial else None
         self._metadata["FILTER"] = self._filter if self._filter else None
         self._metadata["CALIB_ID"] = self._calibId if self._calibId else None
-=======
-        self._metadata["INSTRUME"] = self._instrument
-        self._metadata["RAFTNAME"] = self._raftName
-        self._metadata["SLOTNAME"] = self._slotName
-        self._metadata["DETECTOR"] = self._detectorId
-        self._metadata["DET_NAME"] = self._detectorName
-        self._metadata["DET_SER"] = self._detectorSerial
-        self._metadata["FILTER"] = self._filter
-        self._metadata["CALIB_ID"] = self._calibId
->>>>>>> 52261ee... Handle metadata fields consistently.
 
         mdSupplemental.update(kwargs)
         mdOriginal.update(mdSupplemental)

--- a/python/lsst/ip/isr/calibType.py
+++ b/python/lsst/ip/isr/calibType.py
@@ -181,11 +181,19 @@ class IsrCalib(abc.ABC):
 
         if setCalibId:
             values = []
+<<<<<<< HEAD
             values.append(f"instrument={self._instrument}") if self._instrument else None
             values.append(f"raftName={self._raftName}") if self._raftName else None
             values.append(f"detectorName={self._detectorName}") if self._detectorName else None
             values.append(f"detector={self.detector}") if self._detector else None
             values.append(f"filter={self._filter}") if self._filter else None
+=======
+            values.append(f"instrument={self._instrument}") if self._instrument
+            values.append(f"raftName={self._raftName}") if self._raftName
+            values.append(f"detectorName={self._detectorName}") if self._detectorName
+            values.append(f"detector={self.detector}") if self._detector
+            values.append(f"filter={self._filter}") if self._filter
+>>>>>>> 52261ee... Handle metadata fields consistently.
             self._calibId = " ".join(values)
 
         if setDate:
@@ -194,6 +202,7 @@ class IsrCalib(abc.ABC):
             mdSupplemental['CALIB_CREATION_DATE'] = date.date().isoformat()
             mdSupplemental['CALIB_CREATION_TIME'] = date.time().isoformat()
 
+<<<<<<< HEAD
         self._metadata["INSTRUME"] = self._instrument if self._instrument else None
         self._metadata["RAFTNAME"] = self._raftName if self._raftName else None
         self._metadata["SLOTNAME"] = self._slotName if self._slotName else None
@@ -202,6 +211,16 @@ class IsrCalib(abc.ABC):
         self._metadata["DET_SER"] = self._detectorSerial if self._detectorSerial else None
         self._metadata["FILTER"] = self._filter if self._filter else None
         self._metadata["CALIB_ID"] = self._calibId if self._calibId else None
+=======
+        self._metadata["INSTRUME"] = self._instrument
+        self._metadata["RAFTNAME"] = self._raftName
+        self._metadata["SLOTNAME"] = self._slotName
+        self._metadata["DETECTOR"] = self._detectorId
+        self._metadata["DET_NAME"] = self._detectorName
+        self._metadata["DET_SER"] = self._detectorSerial
+        self._metadata["FILTER"] = self._filter
+        self._metadata["CALIB_ID"] = self._calibId
+>>>>>>> 52261ee... Handle metadata fields consistently.
 
         mdSupplemental.update(kwargs)
         mdOriginal.update(mdSupplemental)

--- a/python/lsst/ip/isr/linearize.py
+++ b/python/lsst/ip/isr/linearize.py
@@ -60,6 +60,36 @@ class Linearizer(IsrCalib):
     RuntimeError :
         Raised if the supplied table is not 2D, or if the table has fewer
         columns than rows (indicating that the indices are swapped).
+
+    Notes
+    -----
+    The linearizer attributes stored are:
+
+    hasLinearity : `bool`
+        Whether a linearity correction is defined for this detector.
+    override : `bool`
+        Whether the detector parameters should be overridden.
+    ampNames : `list` [`str`]
+        List of amplifier names to correct.
+    linearityCoeffs : `dict` [`str`, `numpy.array`]
+        Coefficients to use in correction.  Indexed by amplifier
+        names.  The format of the array depends on the type of
+        correction to apply.
+    linearityType : `dict` [`str`, `str`]
+        Type of correction to use, indexed by amplifier names.
+    linearityBBox : `dict` [`str`, `lsst.geom.Box2I`]
+        Bounding box the correction is valid over, indexed by
+        amplifier names.
+    fitParams : `dict` [`str`, `numpy.array`], optional
+        Linearity fit parameters used to construct the correction
+        coefficients, indexed as above.
+    fitParamsErr : `dict` [`str`, `numpy.array`], optional
+        Uncertainty values of the linearity fit parameters used to
+        construct the correction coefficients, indexed as above.
+    fitChiSq : `dict` [`str`, `float`], optional
+        Chi-squared value of the linearity fit, indexed as above.
+    tableData : `numpy.array`, optional
+        Lookup table data for the linearity correction.
     """
     _OBSTYPE = "LINEARIZER"
     _SCHEMA = 'Gen3 Linearizer'


### PR DESCRIPTION
This makes the linearity dataset a subclass of IsrCalib, which hopefully gives better code reuse and consistency between datasets.