### PR TITLE
DM-26484: Run read noise eotest task at NCSA

### DIFF
--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -1382,6 +1382,18 @@ class IsrTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
                         self.metadata.set(f"ISR OSCAN {amp.getName()} STDEV", qaStdev)
                         self.log.debug("  Overscan stats for amplifer %s: %f +/- %f",
                                        amp.getName(), qaMedian, qaStdev)
+
+                        # Residuals after overscan correction
+                        qaStatsAfter = afwMath.makeStatistics(overscanResults.overscanImage,
+                                                              afwMath.MEDIAN | afwMath.STDEVCLIP)
+                        qaMedianAfter = qaStatsAfter.getValue(afwMath.MEDIAN)
+                        qaStdevAfter = qaStatsAfter.getValue(afwMath.STDEVCLIP)
+
+                        self.metadata.set(f"ISR OSCAN {amp.getName()} MEDIAN AFTER CORRECTION", qaMedianAfter)
+                        self.metadata.set(f"ISR OSCAN {amp.getName()} STDEV AFTTER CORRECTION", qaStdevAfter)
+                        self.log.debug("  Overscan stats for amplifer %s after correction: %f +/- %f",
+                                       amp.getName(), qaMedianAfter, qaStdevAfter)
+
                         ccdExposure.getMetadata().set('OVERSCAN', "Overscan corrected")
                 else:
                     if badAmp:

--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -1378,8 +1378,8 @@ class IsrTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
                             qaMedian = qaStats.getValue(afwMath.MEDIAN)
                             qaStdev = qaStats.getValue(afwMath.STDEVCLIP)
 
-                        self.metadata.set(f"ISR OSCAN {amp.getName()} MEDIAN", qaMedian)
-                        self.metadata.set(f"ISR OSCAN {amp.getName()} STDEV", qaStdev)
+                        self.metadata.set(f"FIT MEDIAN {amp.getName()}", qaMedian)
+                        self.metadata.set(f"FIT STDEV {amp.getName()}", qaStdev)
                         self.log.debug("  Overscan stats for amplifer %s: %f +/- %f",
                                        amp.getName(), qaMedian, qaStdev)
 
@@ -1389,8 +1389,8 @@ class IsrTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
                         qaMedianAfter = qaStatsAfter.getValue(afwMath.MEDIAN)
                         qaStdevAfter = qaStatsAfter.getValue(afwMath.STDEVCLIP)
 
-                        self.metadata.set(f"ISR OSCAN {amp.getName()} MEDIAN AFTER CORRECTION", qaMedianAfter)
-                        self.metadata.set(f"ISR OSCAN {amp.getName()} STDEV AFTTER CORRECTION", qaStdevAfter)
+                        self.metadata.set(f"RESIDUAL MEDIAN {amp.getName()}", qaMedianAfter)
+                        self.metadata.set(f"RESIDUAL STDEV {amp.getName()}", qaStdevAfter)
                         self.log.debug("  Overscan stats for amplifer %s after correction: %f +/- %f",
                                        amp.getName(), qaMedianAfter, qaStdevAfter)
 


### PR DESCRIPTION
It was also necessary to report statistics after overscan correction to compare with eoTest. This ticket implements the changes to do that reporting in the metadata. 