### PR TITLE
DM-27103: Not all IsrCalib tests round trip calibrations

### DIFF
--- a/python/lsst/ip/isr/brighterFatterKernel.py
+++ b/python/lsst/ip/isr/brighterFatterKernel.py
@@ -88,24 +88,6 @@ class BrighterFatterKernel(IsrCalib):
                                         'badAmps', 'gain', 'noise', 'meanXcorrs', 'valid',
                                         'ampKernels', 'detKernels'])
 
-    def __eq__(self, other):
-        """Calibration equivalence
-        """
-        if not isinstance(other, self.__class__):
-            return False
-
-        for attr in self._requiredAttributes:
-            attrSelf = getattr(self, attr)
-            attrOther = getattr(other, attr)
-            if isinstance(attrSelf, dict) and isinstance(attrOther, dict):
-                for ampName in attrSelf:
-                    if not np.allclose(attrSelf[ampName], attrOther[ampName], equal_nan=True):
-                        return False
-            else:
-                if attrSelf != attrOther:
-                    return False
-        return True
-
     def updateMetadata(self, setDate=False, **kwargs):
         """Update calibration metadata.
 

--- a/python/lsst/ip/isr/crosstalk.py
+++ b/python/lsst/ip/isr/crosstalk.py
@@ -150,6 +150,7 @@ class CrosstalkCalib(IsrCalib):
 
         """
         if detector.hasCrosstalk() or coeffVector:
+            self._detectorId = detector.getId()
             self._detectorName = detector.getName()
             self._detectorSerial = detector.getSerial()
 
@@ -168,7 +169,11 @@ class CrosstalkCalib(IsrCalib):
                 raise RuntimeError("Crosstalk coefficients do not match detector shape. "
                                    f"{self.crosstalkShape} {self.nAmp}")
 
+            self.coeffErr = np.zeros(self.crosstalkShape)
+            self.coeffNum = np.zeros(self.crosstalkShape, dtype=int)
+            self.coeffValid = np.ones(self.crosstalkShape, dtype=bool)
             self.interChip = {}
+
             self.hasCrosstalk = True
             self.updateMetadata()
         return self
@@ -334,11 +339,11 @@ class CrosstalkCalib(IsrCalib):
         inDict['nAmp'] = metadata['NAMP']
 
         inDict['coeffs'] = coeffTable['CT_COEFFS']
-        if 'CT_ERRORS' in coeffTable:
+        if 'CT_ERRORS' in coeffTable.columns:
             inDict['coeffErr'] = coeffTable['CT_ERRORS']
-        if 'CT_COUNTS' in coeffTable:
+        if 'CT_COUNTS' in coeffTable.columns:
             inDict['coeffNum'] = coeffTable['CT_COUNTS']
-        if 'CT_VALID' in coeffTable:
+        if 'CT_VALID' in coeffTable.columns:
             inDict['coeffValid'] = coeffTable['CT_VALID']
 
         if len(tableList) > 1:

--- a/python/lsst/ip/isr/ptcDataset.py
+++ b/python/lsst/ip/isr/ptcDataset.py
@@ -197,24 +197,6 @@ class PhotonTransferCurveDataset(IsrCalib):
                                         'aMatrix', 'bMatrix', 'finalVars', 'finalModelVars', 'finalMeans',
                                         'photoCharge'])
 
-    def __eq__(self, other):
-        """Calibration equivalence
-        """
-        if not isinstance(other, self.__class__):
-            return False
-
-        for attr in self._requiredAttributes:
-            attrSelf = getattr(self, attr)
-            attrOther = getattr(other, attr)
-            if isinstance(attrSelf, dict) and isinstance(attrOther, dict):
-                for ampName in attrSelf:
-                    if not np.allclose(attrSelf[ampName], attrOther[ampName], equal_nan=True):
-                        return False
-            else:
-                if attrSelf != attrOther:
-                    return False
-        return True
-
     def setAmpValues(self, ampName, inputExpIdPair=[(np.nan, np.nan)], expIdMask=[np.nan],
                      rawExpTime=[np.nan], rawMean=[np.nan], rawVar=[np.nan], photoCharge=[np.nan],
                      gain=np.nan, gainErr=np.nan, noise=np.nan, noiseErr=np.nan, ptcFitPars=[np.nan],

--- a/tests/test_crosstalk.py
+++ b/tests/test_crosstalk.py
@@ -275,6 +275,27 @@ class CrosstalkTestCase(lsst.utils.tests.TestCase):
         isr.crosstalk.run(exposure, crosstalk=calib, crosstalkSources=ctSources)
         self.checkSubtracted(exposure)
 
+    def test_crosstalkIO(self):
+        """Test that crosstalk doesn't change on being converted to persistable formats."""
+
+        # Add the interchip crosstalk as in the previous test.
+        exposure = self.exposure
+
+        coeff = np.array(self.crosstalk).transpose()
+        calib = CrosstalkCalib().fromDetector(exposure.getDetector(), coeffVector=coeff)
+        # Now convert this into zero intra-chip, full inter-chip:
+        calib.interChip['detector 2'] = coeff
+
+        outPath = tempfile.mktemp() + '.yaml'
+        calib.writeText(outPath)
+        newCrosstalk = CrosstalkCalib().readText(outPath)
+        self.assertEqual(calib, newCrosstalk)
+
+        outPath = tempfile.mktemp() + '.fits'
+        calib.writeFits(outPath)
+        newCrosstalk = CrosstalkCalib().readFits(outPath)
+        self.assertEqual(calib, newCrosstalk)
+
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass


### PR DESCRIPTION
This fixes the missing tests, and enhances the base class __eq__ to reduce code duplication.