### PR TITLE
Defects instantiation creates undefined/infinite bbox

### DIFF
--- a/python/lsst/ip/isr/defects.py
+++ b/python/lsst/ip/isr/defects.py
@@ -185,6 +185,10 @@ class Defects(IsrCalib):
         if self._bulk_update:
             return
 
+        # If we have no defects, there is nothing to normalize.
+        if len(self) == 0:
+            return
+
         # work out the minimum and maximum bounds from all defect regions.
         minX, minY, maxX, maxY = float('inf'), float('inf'), float('-inf'), float('-inf')
         for defect in self:


### PR DESCRIPTION
Do not normalize an empty Defects() object.