### PR TITLE
DM-30015: Update Sphinx conf.py for documenteer 0.6

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,13 +1,13 @@
 """Sphinx configuration file for an LSST stack package.
-
-This configuration only affects single-package Sphinx documenation builds.
+This configuration only affects single-package Sphinx documentation builds.
+For more information, see:
+https://developer.lsst.io/stack/building-single-package-docs.html
 """
 
-from documenteer.sphinxconfig.stackconf import build_package_configs
-import lsst.ip.isr
+from documenteer.conf.pipelinespkg import *
 
 
-_g = globals()
-_g.update(build_package_configs(
-    project_name='ip_isr',
-    version=lsst.ip.isr.version.__version__))
+project = "ip_isr"
+html_theme_options["logotext"] = project
+html_title = project
+html_short_title = project

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,9 +4,13 @@ max-doc-length = 79
 ignore = E133, E226, E228, N802, N803, N806, N812, N815, N816, W503
 # TODO: remove E266 when Task documentation is converted to rst in DM-14207.
 exclude =
-    __init__.py
     # TODO: Remove E266 once doxygen is converted to numpydoc
     assembleCcdTask.py E266
+    bin,
+    doc/conf.py,
+    **/*/__init__.py,
+    **/*/version.py,
+    tests/.tests
 
 [tool:pytest]
 addopts = --flake8


### PR DESCRIPTION
Updates based on the latest updates in the package template (https://github.com/lsst/templates/tree/master/project_templates/stack_package)

- Add a basic README
- Update doc/conf.py for the documenteer 0.6 Sphinx configuration API