### PR TITLE
DM-31174: str() method failure on lsst.ip.isr.Defects class

### DIFF
--- a/python/lsst/ip/isr/defects.py
+++ b/python/lsst/ip/isr/defects.py
@@ -168,7 +168,7 @@ class Defects(IsrCalib):
         return True
 
     def __str__(self):
-        baseStr = super().__str__(self)
+        baseStr = super().__str__()
         return baseStr + ",".join(str(d.getBBox()) for d in self) + ")"
 
     def _normalize(self):


### PR DESCRIPTION
Fix Defects __str__ method.