### PR TITLE
DM-31394: Overscan subtraction can create negative variance

### DIFF
--- a/tests/test_empiricalVariance.py
+++ b/tests/test_empiricalVariance.py
@@ -123,6 +123,7 @@ class EmpiricalVarianceTestCast(lsst.utils.tests.TestCase):
         self.config.doNanMasking = False
         self.config.doInterpolate = False
 
+        self.config.maskNegativeVariance = False  # This runs on mocks.
         # Set the things that match our test setup
         self.config.overscan.fitType = "CHEB"
         self.config.overscan.order = 1

--- a/tests/test_isrTask.py
+++ b/tests/test_isrTask.py
@@ -429,6 +429,31 @@ class IsrTaskUnTrimmedTestCases(lsst.utils.tests.TestCase):
         self.assertEqual(countMaskedPixels(results.exposure, "SUSPECT"), 0)
         self.assertEqual(countMaskedPixels(results.exposure, "BAD"), 40800)
 
+    def test_maskingCase_noMasking(self):
+        """Test masking cases of configuration parameters.
+        """
+        self.batchSetConfiguration(True)
+        self.config.overscanFitType = "POLY"
+        self.config.overscanOrder = 1
+
+        self.config.doSaturation = False
+        self.config.doWidenSaturationTrails = False
+        self.config.doSaturationInterpolation = False
+        self.config.doSuspect = False
+        self.config.doSetBadRegions = False
+        self.config.doDefect = False
+        self.config.doBrighterFatter = False
+
+        self.config.maskNegativeVariance = False
+        self.config.doInterpolate = False
+
+        results = self.validateIsrResults()
+
+        self.assertEqual(countMaskedPixels(results.exposure, "SAT"), 0)
+        self.assertEqual(countMaskedPixels(results.exposure, "INTRP"), 0)
+        self.assertEqual(countMaskedPixels(results.exposure, "SUSPECT"), 0)
+        self.assertEqual(countMaskedPixels(results.exposure, "BAD"), 0)
+
     def test_maskingCase_satMasking(self):
         """Test masking cases of configuration parameters.
         """

--- a/tests/test_isrTask.py
+++ b/tests/test_isrTask.py
@@ -404,7 +404,7 @@ class IsrTaskUnTrimmedTestCases(lsst.utils.tests.TestCase):
         with self.assertRaises(RuntimeError):
             self.validateIsrResults()
 
-    def test_maskingCase_noMasking(self):
+    def test_maskingCase_negativeVariance(self):
         """Test masking cases of configuration parameters.
         """
         self.batchSetConfiguration(True)
@@ -419,12 +419,15 @@ class IsrTaskUnTrimmedTestCases(lsst.utils.tests.TestCase):
         self.config.doDefect = False
         self.config.doBrighterFatter = False
 
+        self.config.maskNegativeVariance = True
+        self.config.doInterpolate = False
+
         results = self.validateIsrResults()
 
         self.assertEqual(countMaskedPixels(results.exposure, "SAT"), 0)
         self.assertEqual(countMaskedPixels(results.exposure, "INTRP"), 0)
         self.assertEqual(countMaskedPixels(results.exposure, "SUSPECT"), 0)
-        self.assertEqual(countMaskedPixels(results.exposure, "BAD"), 0)
+        self.assertEqual(countMaskedPixels(results.exposure, "BAD"), 40800)
 
     def test_maskingCase_satMasking(self):
         """Test masking cases of configuration parameters.
@@ -442,6 +445,8 @@ class IsrTaskUnTrimmedTestCases(lsst.utils.tests.TestCase):
         self.config.doSetBadRegions = False
         self.config.doDefect = False
         self.config.doBrighterFatter = False
+
+        self.config.maskNegativeVariance = False  # These are mock images.
 
         results = self.validateIsrResults()
 
@@ -466,6 +471,8 @@ class IsrTaskUnTrimmedTestCases(lsst.utils.tests.TestCase):
         self.config.doSetBadRegions = False
         self.config.doDefect = False
         self.config.doBrighterFatter = False
+
+        self.config.maskNegativeVariance = False  # These are mock images.
 
         results = self.validateIsrResults()
 
@@ -492,6 +499,8 @@ class IsrTaskUnTrimmedTestCases(lsst.utils.tests.TestCase):
         self.config.doDefect = False
         self.config.doBrighterFatter = False
 
+        self.config.maskNegativeVariance = False  # These are mock images.
+
         results = self.validateIsrResults()
 
         self.assertEqual(countMaskedPixels(results.exposure, "SAT"), 0)
@@ -516,6 +525,8 @@ class IsrTaskUnTrimmedTestCases(lsst.utils.tests.TestCase):
 
         self.config.doSetBadRegions = False
         self.config.doBrighterFatter = False
+
+        self.config.maskNegativeVariance = False  # These are mock images.
 
         results = self.validateIsrResults()
 
@@ -543,6 +554,8 @@ class IsrTaskUnTrimmedTestCases(lsst.utils.tests.TestCase):
         self.config.doSetBadRegions = False
         self.config.doBrighterFatter = False
 
+        self.config.maskNegativeVariance = False  # These are mock images.
+
         results = self.validateIsrResults()
 
         self.assertEqual(countMaskedPixels(results.exposure, "SAT"), 0)
@@ -566,6 +579,8 @@ class IsrTaskUnTrimmedTestCases(lsst.utils.tests.TestCase):
         self.config.doDefect = True
         self.config.doSetBadRegions = True
         self.config.doBrighterFatter = False
+
+        self.config.maskNegativeVariance = False  # These are mock images.
 
         results = self.validateIsrResults()
 


### PR DESCRIPTION
Add options to mask pixels with negative variance by default.  This should never happen on science images, so this should be a safe change.

Add a test to check this, but let it be disabled in most of the IsrTask tests, as those operate on mock images that are not necessarily constructed the same way a science image is.