### PR TITLE
DM-31696: Switch to python logging

### DIFF
--- a/python/lsst/ip/isr/brighterFatterKernel.py
+++ b/python/lsst/ip/isr/brighterFatterKernel.py
@@ -50,7 +50,7 @@ class BrighterFatterKernel(IsrCalib):
     ----------
     level : `str`
         Level the kernels will be generated for.
-    log : `lsst.log.Log`, optional
+    log : `logging.Logger`, optional
         Log to write messages to.
     **kwargs :
         Parameters to pass to parent constructor.

--- a/python/lsst/ip/isr/calibType.py
+++ b/python/lsst/ip/isr/calibType.py
@@ -20,6 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import abc
 import datetime
+import logging
 import os.path
 import warnings
 import yaml
@@ -28,7 +29,6 @@ import numpy as np
 from astropy.table import Table
 from astropy.io import fits
 
-from lsst.log import Log
 from lsst.daf.base import PropertyList
 
 
@@ -55,7 +55,7 @@ class IsrCalib(abc.ABC):
         Camera to extract metadata from.
     detector : `lsst.afw.cameraGeom.Detector`, optional
         Detector to extract metadata from.
-    log : `lsst.log.Log`, optional
+    log : `logging.Logger`, optional
         Log for messages.
     """
     _OBSTYPE = 'generic'
@@ -81,7 +81,7 @@ class IsrCalib(abc.ABC):
                                         '_detectorName', '_detectorSerial', '_detectorId',
                                         '_filter', '_calibId', '_metadata'])
 
-        self.log = log if log else Log.getLogger(__name__.partition(".")[2])
+        self.log = log if log else logging.getLogger(__name__.partition(".")[2])
 
         if detector:
             self.fromDetector(detector)

--- a/python/lsst/ip/isr/crosstalk.py
+++ b/python/lsst/ip/isr/crosstalk.py
@@ -47,7 +47,7 @@ class CrosstalkCalib(IsrCalib):
         Detector to use to pull coefficients from.
     nAmp : `int`, optional
         Number of amplifiers to initialize.
-    log : `lsst.log.Log`, optional
+    log : `logging.Logger`, optional
         Log to write messages to.
     **kwargs :
         Parameters to pass to parent constructor.

--- a/python/lsst/ip/isr/isrFunctions.py
+++ b/python/lsst/ip/isr/isrFunctions.py
@@ -884,7 +884,7 @@ def checkFilter(exposure, filterList, log):
         Exposure to examine.
     filterList : `list` [`str`]
         List of physical_filter names to check.
-    log : `lsst.log.Log`
+    log : `logging.Logger`
         Logger to handle messages.
 
     Returns
@@ -921,7 +921,7 @@ def getPhysicalFilter(filterLabel, log):
     filterLabel : `lsst.afw.image.FilterLabel`
         The `lsst.afw.image.FilterLabel` object from which to derive the
         physical filter label.
-    log : `lsst.log.Log`
+    log : `logging.Logger`
         Logger to handle messages.
 
     Returns

--- a/python/lsst/ip/isr/linearize.py
+++ b/python/lsst/ip/isr/linearize.py
@@ -51,7 +51,7 @@ class Linearizer(IsrCalib):
         (numpy default "C" order)
     detector : `lsst.afw.cameraGeom.Detector`, optional
         Detector object.  Passed to self.fromDetector() on init.
-    log : `lsst.log.Log`, optional
+    log : `logging.Logger`, optional
         Logger to handle messages.
     kwargs : `dict`, optional
         Other keyword arguments to pass to the parent init.
@@ -438,7 +438,7 @@ class Linearizer(IsrCalib):
         detector : `~lsst.afw.cameraGeom.detector`
             Detector to use for linearity parameters if not already
             populated.
-        log : `~lsst.log.Log`, optional
+        log : `~logging.Logger`, optional
             Log object to use for logging.
         """
         if log is None:
@@ -501,7 +501,7 @@ class LinearizeBase(metaclass=abc.ABCMeta):
             ``"table"``
                 Lookup table data (`numpy.array`).
             ``"log"``
-                Logger to handle messages (`lsst.log.Log`).
+                Logger to handle messages (`logging.Logger`).
 
         Returns
         -------
@@ -553,7 +553,7 @@ class LinearizeLookupTable(LinearizeBase):
             ``"table"``
                 Lookup table data (`numpy.array`).
             ``"log"``
-                Logger to handle messages (`lsst.log.Log`).
+                Logger to handle messages (`logging.Logger`).
 
         Returns
         -------
@@ -624,7 +624,7 @@ class LinearizePolynomial(LinearizeBase):
                 should have a length of n-1 ("k0" and "k1" are
                 not needed for the correction).
             ``"log"``
-                Logger to handle messages (`lsst.log.Log`).
+                Logger to handle messages (`logging.Logger`).
 
         Returns
         -------
@@ -668,7 +668,7 @@ class LinearizeSquared(LinearizeBase):
             ``"coeffs"``
                 Coefficient vector (`list` or `numpy.array`).
             ``"log"``
-                Logger to handle messages (`lsst.log.Log`).
+                Logger to handle messages (`logging.Logger`).
 
         Returns
         -------
@@ -714,7 +714,7 @@ class LinearizeSpline(LinearizeBase):
             ``"coeffs"``
                 Coefficient vector (`list` or `numpy.array`).
             ``"log"``
-                Logger to handle messages (`lsst.log.Log`).
+                Logger to handle messages (`logging.Logger`).
 
         Returns
         -------
@@ -752,7 +752,7 @@ class LinearizeProportional(LinearizeBase):
             ``"coeffs"``
                 Coefficient vector (`list` or `numpy.array`).
             ``"log"``
-                Logger to handle messages (`lsst.log.Log`).
+                Logger to handle messages (`logging.Logger`).
 
         Returns
         -------
@@ -781,7 +781,7 @@ class LinearizeNone(LinearizeBase):
             ``"coeffs"``
                 Coefficient vector (`list` or `numpy.array`).
             ``"log"``
-                Logger to handle messages (`lsst.log.Log`).
+                Logger to handle messages (`logging.Logger`).
 
         Returns
         -------

--- a/tests/test_linearize.py
+++ b/tests/test_linearize.py
@@ -21,6 +21,7 @@
 
 import unittest
 
+import logging
 import numpy as np
 
 import lsst.utils.tests
@@ -31,7 +32,6 @@ import lsst.afw.cameraGeom as cameraGeom
 from lsst.afw.geom.testUtils import BoxGrid
 from lsst.afw.image.testUtils import makeRampImage
 from lsst.ip.isr import applyLookupTable, Linearizer
-from lsst.log import Log
 
 
 def referenceImage(image, detector, linearityType, inputData, table=None):
@@ -127,7 +127,7 @@ class LinearizeTestCase(lsst.utils.tests.TestCase):
         # Spline coefficients: should match a 1e-6 Squared solution
         self.splineCoeffs = np.array([-100, 0.0, 1000, 2000, 3000, 4000, 5000,
                                       0.0, 0.0, 1.0, 4.0, 9.0, 16.0, 25.0])
-        self.log = Log.getLogger("ip.isr.testLinearizer")
+        self.log = logging.getLogger("ip.isr.testLinearizer")
 
     def tearDown(self):
         # destroy LSST objects so memory test passes.

--- a/tests/test_linearizeLookupTable.py
+++ b/tests/test_linearizeLookupTable.py
@@ -21,7 +21,7 @@
 #
 import unittest
 import pickle
-
+import logging
 import numpy as np
 
 import lsst.utils.tests
@@ -31,7 +31,6 @@ import lsst.afw.cameraGeom as cameraGeom
 from lsst.afw.geom.testUtils import BoxGrid
 from lsst.afw.image.testUtils import makeRampImage
 from lsst.ip.isr import applyLookupTable, Linearizer
-from lsst.log import Log
 
 
 def refLinearize(image, detector, table):
@@ -82,7 +81,7 @@ class LinearizeLookupTableTestCase(lsst.utils.tests.TestCase):
             inImage = makeRampImage(bbox=self.bbox, start=-5, stop=250, imageClass=imageClass)
             table = self.makeTable(inImage)
 
-            log = Log.getLogger("ip.isr.LinearizeLookupTable")
+            log = logging.getLogger("ip.isr.LinearizeLookupTable")
 
             measImage = inImage.Factory(inImage, True)
             llt = Linearizer(table=table, detector=self.detector)
@@ -97,7 +96,7 @@ class LinearizeLookupTableTestCase(lsst.utils.tests.TestCase):
             self.assertImagesAlmostEqual(refImage, measImage)
 
             # make sure logging is accepted
-            log = Log.getLogger("ip.isr.LinearizeLookupTable")
+            log = logging.getLogger("ip.isr.LinearizeLookupTable")
             linRes = llt.applyLinearity(image=measImage, detector=self.detector, log=log)
 
     def testErrorHandling(self):

--- a/tests/test_linearizeSquared.py
+++ b/tests/test_linearizeSquared.py
@@ -21,6 +21,7 @@
 #
 import unittest
 import pickle
+import logging
 
 import numpy as np
 
@@ -31,7 +32,6 @@ import lsst.afw.cameraGeom as cameraGeom
 from lsst.afw.geom.testUtils import BoxGrid
 from lsst.afw.image.testUtils import makeRampImage
 from lsst.ip.isr import Linearizer
-from lsst.log import Log
 
 
 def refLinearizeSquared(image, detector):
@@ -84,7 +84,7 @@ class LinearizeSquaredTestCase(lsst.utils.tests.TestCase):
             self.assertImagesAlmostEqual(refImage, measImage)
 
             # make sure logging is accepted
-            log = Log.getLogger("ip.isr.LinearizeSquared")
+            log = logging.getLogger("ip.isr.LinearizeSquared")
             linRes = linCorr.applyLinearity(image=measImage, detector=self.detector, log=log)
 
     def testKnown(self):


### PR DESCRIPTION
Python logging now preferred for all python code so change IsrCalib to create a python logger.