### PR TITLE
DM-29955: Add ExposureInfo id getter

### DIFF
--- a/python/lsst/ip/isr/assembleCcdTask.py
+++ b/python/lsst/ip/isr/assembleCcdTask.py
@@ -227,6 +227,7 @@ class AssembleCcdTask(pipeBase.Task):
         outExposure.setMetadata(exposureMetadata)
 
         # note: don't copy PhotoCalib, because it is assumed to be unknown in raw data
+        outExposure.info.id = inExposure.info.id
         outExposure.setFilterLabel(inExposure.getFilterLabel())
         outExposure.getInfo().setVisitInfo(inExposure.getInfo().getVisitInfo())
 


### PR DESCRIPTION
This PR uses the `id` component added on lsst/afw#613.