### PR TITLE
DM-34407: cp_pipe flat construction fails due to missing vignette polygon

### DIFF
--- a/python/lsst/ip/isr/vignette.py
+++ b/python/lsst/ip/isr/vignette.py
@@ -158,7 +158,7 @@ def maskVignettedRegion(exposure, polygon, maskPlane="NO_DATA", vignetteValue=No
     ----------
     exposure : `lsst.afw.image.Exposure`
         Image whose mask plane is to be updated.
-    polygon : `lsst..afw.geom.Polygon`
+    polygon : `lsst.afw.geom.Polygon`
         Polygon region defining the vignetted region in the pixel coordinates
         of ``exposure``.
     maskPlane : `str`, optional

--- a/python/lsst/ip/isr/vignette.py
+++ b/python/lsst/ip/isr/vignette.py
@@ -177,6 +177,7 @@ def maskVignettedRegion(exposure, polygon, maskPlane="NO_DATA", vignetteValue=No
     log = log if log else logging.getLogger(__name__)
     if not polygon:
         log.info("No polygon provided.  Masking nothing.")
+        return
 
     fullyIlluminated = True
     for corner in exposure.getBBox().getCorners():


### PR DESCRIPTION
Return if no polygon is supplied.