### PR TITLE
DM-27177: Deprecate transitional getFilterLabel API

### DIFF
--- a/python/lsst/ip/isr/assembleCcdTask.py
+++ b/python/lsst/ip/isr/assembleCcdTask.py
@@ -245,7 +245,7 @@ class AssembleCcdTask(pipeBase.Task):
         # note: don't copy PhotoCalib, because it is assumed to be unknown in
         # raw data.
         outExposure.info.id = inExposure.info.id
-        outExposure.setFilterLabel(inExposure.getFilterLabel())
+        outExposure.setFilter(inExposure.getFilter())
         outExposure.getInfo().setVisitInfo(inExposure.getInfo().getVisitInfo())
 
         frame = getDebugFrame(self._display, "assembledExposure")

--- a/python/lsst/ip/isr/isrFunctions.py
+++ b/python/lsst/ip/isr/isrFunctions.py
@@ -901,7 +901,7 @@ def checkFilter(exposure, filterList, log):
     """
     if len(filterList) == 0:
         return False
-    thisFilter = exposure.getFilterLabel()
+    thisFilter = exposure.getFilter()
     if thisFilter is None:
         log.warning("No FilterLabel attached to this exposure!")
         return False

--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -1160,7 +1160,7 @@ class IsrTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
             dateObs = None
 
         ccd = rawExposure.getDetector()
-        filterLabel = rawExposure.getFilterLabel()
+        filterLabel = rawExposure.getFilter()
         physicalFilter = isrFunctions.getPhysicalFilter(filterLabel, self.log)
         rawExposure.mask.addMaskPlane("UNMASKEDNAN")  # needed to match pre DM-15862 processing.
         biasExposure = (self.getIsrExposure(dataRef, self.config.biasDataProductName)
@@ -1418,7 +1418,7 @@ class IsrTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
                 return self.runDataRef(ccdExposure)
 
         ccd = ccdExposure.getDetector()
-        filterLabel = ccdExposure.getFilterLabel()
+        filterLabel = ccdExposure.getFilter()
         physicalFilter = isrFunctions.getPhysicalFilter(filterLabel, self.log)
 
         if not ccd:
@@ -2639,7 +2639,7 @@ class IsrTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
         exposure : `lsst.afw.image.Exposure`
             Exposure to process.
         """
-        filterLabel = exposure.getFilterLabel()
+        filterLabel = exposure.getFilter()
         physicalFilter = isrFunctions.getPhysicalFilter(filterLabel, self.log)
 
         if physicalFilter in self.config.fluxMag0T1:

--- a/tests/test_fringes.py
+++ b/tests/test_fringes.py
@@ -78,7 +78,7 @@ def createFringe(width, height, xFreq, xOffset, yFreq, yOffset):
     array[x, y] = np.sin(xFreq*x + xOffset) + np.sin(yFreq*y + yOffset)
     mi = afwImage.makeMaskedImage(image)
     exp = afwImage.makeExposure(mi)
-    exp.setFilterLabel(afwImage.FilterLabel(band='y', physical='FILTER'))
+    exp.setFilter(afwImage.FilterLabel(band='y', physical='FILTER'))
     return exp
 
 
@@ -217,7 +217,7 @@ class FringeTestCase(lsst.utils.tests.TestCase):
             image.scaledPlus(s, f.getMaskedImage().getImage())
         mi = afwImage.makeMaskedImage(image)
         exp = afwImage.makeExposure(mi)
-        exp.setFilterLabel(afwImage.FilterLabel(physical='FILTER'))
+        exp.setFilter(afwImage.FilterLabel(physical='FILTER'))
 
         task = FringeTask(name="multiFringe", config=self.config)
         self.checkFringe(task, exp, fringeList, stddevMax=1.0e-2)
@@ -274,7 +274,7 @@ class FringeTestCase(lsst.utils.tests.TestCase):
         dataRef = isrMock.FringeDataRefMock(config=config)
 
         exp = dataRef.get("raw")
-        exp.setFilterLabel(afwImage.FilterLabel(physical='FILTER'))
+        exp.setFilter(afwImage.FilterLabel(physical='FILTER'))
         medianBefore = np.nanmedian(exp.getImage().getArray())
         fringes = task.readFringes(dataRef, assembler=None)
 


### PR DESCRIPTION
This PR removes references to `getFilterLabel` and similarly-named methods, replacing them with `getFilter` (etc.) methods backed by `FilterLabel`.