### PR TITLE
DM-35349: Fix brighter fatter kernel backwards compatibility

### DIFF
--- a/python/lsst/ip/isr/brighterFatterKernel.py
+++ b/python/lsst/ip/isr/brighterFatterKernel.py
@@ -233,7 +233,7 @@ class BrighterFatterKernel(IsrCalib):
 
         calibVersion = dictionary['metadata']['bfk_VERSION']
         if calibVersion == 1.0:
-            cls().log.warning("Old Version of brightter-fatter kernel found. Current version: "
+            calib.log.warning("Old Version of brighter-fatter kernel found. Current version: "
                               f"{calib._VERSION}. The new attribute 'expIdMask' will be "
                               "populated with 'True' values, and the new attributes 'rawMeans'"
                               "and 'rawVariances' will be populated with the masked 'means'."

--- a/python/lsst/ip/isr/brighterFatterKernel.py
+++ b/python/lsst/ip/isr/brighterFatterKernel.py
@@ -245,11 +245,13 @@ class BrighterFatterKernel(IsrCalib):
             calib.rawMeans = {amp: np.array(dictionary['means'][amp]) for amp in dictionary['means']}
             calib.rawVariances = {amp: np.array(dictionary['variances'][amp]) for amp in
                                   dictionary['variances']}
-        else:
+        elif calibVersion == 1.1:
             calib.expIdMask = {amp: np.array(dictionary['expIdMask'][amp]) for amp in dictionary['expIdMask']}
             calib.rawMeans = {amp: np.array(dictionary['rawMeans'][amp]) for amp in dictionary['rawMeans']}
             calib.rawVariances = {amp: np.array(dictionary['rawVariances'][amp]) for amp in
                                   dictionary['rawVariances']}
+        else:
+            raise RuntimeError(f"Unknown version for brighter-fatter kernel: {calibVersion}")
 
         # Lengths for reshape:
         _, smallLength, nObs = calib.getLengths()
@@ -346,7 +348,7 @@ class BrighterFatterKernel(IsrCalib):
         # Determine version for expected values.  The ``fromDict``
         # method can unpack either, but the appropriate fields need to
         # be supplied.
-        calibVersion = metadata.get('bfk_VERSION', 1.0)
+        calibVersion = metadata['bfk_VERSION']
 
         if calibVersion == 1.0:
             # We expect to find ``means`` and ``variances`` for this


### PR DESCRIPTION
Fix brighter-fatter kernel backwards compatibility.

This fixes the translation between the FITS table and the intermediate dictionary representation.