### PR TITLE
DM-33429: Add ability to do both serial and parallel overscan correction

### DIFF
--- a/python/lsst/ip/isr/isrFunctions.py
+++ b/python/lsst/ip/isr/isrFunctions.py
@@ -33,7 +33,6 @@ from lsst.meas.algorithms.detection import SourceDetectionTask
 
 from contextlib import contextmanager
 
-from .overscan import OverscanCorrectionTask, OverscanCorrectionTaskConfig
 from .defects import Defects
 
 
@@ -439,84 +438,6 @@ def illuminationCorrection(maskedImage, illumMaskedImage, illumScale, trimToFit=
                            (maskedImage.getBBox(afwImage.LOCAL), illumMaskedImage.getBBox(afwImage.LOCAL)))
 
     maskedImage.scaledDivides(1.0/illumScale, illumMaskedImage)
-
-
-def overscanCorrection(ampMaskedImage, overscanImage, fitType='MEDIAN', order=1, collapseRej=3.0,
-                       statControl=None, overscanIsInt=True):
-    """Apply overscan correction in place.
-
-    Parameters
-    ----------
-    ampMaskedImage : `lsst.afw.image.MaskedImage`
-        Image of amplifier to correct; modified.
-    overscanImage : `lsst.afw.image.Image` or `lsst.afw.image.MaskedImage`
-        Image of overscan; modified.
-    fitType : `str`
-        Type of fit for overscan correction. May be one of:
-
-        - ``MEAN``: use mean of overscan.
-        - ``MEANCLIP``: use clipped mean of overscan.
-        - ``MEDIAN``: use median of overscan.
-        - ``MEDIAN_PER_ROW``: use median per row of overscan.
-        - ``POLY``: fit with ordinary polynomial.
-        - ``CHEB``: fit with Chebyshev polynomial.
-        - ``LEG``: fit with Legendre polynomial.
-        - ``NATURAL_SPLINE``: fit with natural spline.
-        - ``CUBIC_SPLINE``: fit with cubic spline.
-        - ``AKIMA_SPLINE``: fit with Akima spline.
-
-    order : `int`
-        Polynomial order or number of spline knots; ignored unless
-        ``fitType`` indicates a polynomial or spline.
-    statControl : `lsst.afw.math.StatisticsControl`
-        Statistics control object.  In particular, we pay attention to
-        ``numSigmaClip``.
-    overscanIsInt : `bool`
-        Treat the overscan region as consisting of integers, even if it's been
-        converted to float.  E.g. handle ties properly.
-
-    Returns
-    -------
-    result : `lsst.pipe.base.Struct`
-        Result struct with components:
-
-        - ``imageFit``: Value(s) removed from image (scalar or
-            `lsst.afw.image.Image`)
-        - ``overscanFit``: Value(s) removed from overscan (scalar or
-            `lsst.afw.image.Image`)
-        - ``overscanImage``: Overscan corrected overscan region
-            (`lsst.afw.image.Image`)
-    Raises
-    ------
-    RuntimeError
-        Raised if ``fitType`` is not an allowed value.
-
-    Notes
-    -----
-    The ``ampMaskedImage`` and ``overscanImage`` are modified, with the fit
-    subtracted. Note that the ``overscanImage`` should not be a subimage of
-    the ``ampMaskedImage``, to avoid being subtracted twice.
-
-    Debug plots are available for the SPLINE fitTypes by setting the
-    `debug.display` for `name` == "lsst.ip.isr.isrFunctions".  These
-    plots show the scatter plot of the overscan data (collapsed along
-    the perpendicular dimension) as a function of position on the CCD
-    (normalized between +/-1).
-    """
-    ampImage = ampMaskedImage.getImage()
-
-    config = OverscanCorrectionTaskConfig()
-    if fitType:
-        config.fitType = fitType
-    if order:
-        config.order = order
-    if collapseRej:
-        config.numSigmaClip = collapseRej
-    if overscanIsInt:
-        config.overscanIsInt = True
-
-    overscanTask = OverscanCorrectionTask(config=config)
-    return overscanTask.run(ampImage, overscanImage)
 
 
 def brighterFatterCorrection(exposure, kernel, maxIter, threshold, applyGain, gains=None):

--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -1738,7 +1738,7 @@ class IsrTask(pipeBase.PipelineTask):
         ----------
         ccdExposure : `lsst.afw.image.Exposure`
             Input exposure to be masked.
-        amp : `lsst.afw.table.AmpInfoCatalog`
+        amp : `lsst.afw.cameraGeom.Amplifier`
             Catalog of parameters defining the amplifier on this
             exposure to mask.
         defects : `lsst.ip.isr.Defects`
@@ -1813,8 +1813,8 @@ class IsrTask(pipeBase.PipelineTask):
         region.  The overscan can also be optionally segmented to
         allow for discontinuous overscan responses to be fit
         separately.  The actual overscan subtraction is performed by
-        the `lsst.ip.isr.isrFunctions.overscanCorrection` function,
-        which is called here after the amplifier is preprocessed.
+        the `lsst.ip.isr.overscan.OverscanTask`, which is called here
+        after the amplifier is preprocessed.
 
         Parameters
         ----------
@@ -1835,6 +1835,13 @@ class IsrTask(pipeBase.PipelineTask):
                 Image of the overscan region with the overscan
                 correction applied. This quantity is used to estimate
                 the amplifier read noise empirically.
+            - ``edgeMask`` : `lsst.afw.image.Mask`
+                Mask of the suspect pixels.
+            - ``overscanMean`` : `float`
+                Median overscan fit value.
+            - ``overscanSigma`` : `float`
+                Clipped standard deviation of the overscan after
+                correction.
 
         Raises
         ------
@@ -1871,13 +1878,12 @@ class IsrTask(pipeBase.PipelineTask):
         ----------
         ampExposure : `lsst.afw.image.Exposure`
             Exposure to process.
-        amp : `lsst.afw.table.AmpInfoRecord` or `FakeAmp`
+        amp : `lsst.afw.cameraGeom.Amplifier` or `FakeAmp`
             Amplifier detector data.
         overscanImage : `lsst.afw.image.MaskedImage`, optional.
             Image of overscan, required only for empirical read noise.
         ptcDataset : `lsst.ip.isr.PhotonTransferCurveDataset`, optional
             PTC dataset containing the gains and read noise.
-
 
         Raises
         ------
@@ -2045,7 +2051,7 @@ class IsrTask(pipeBase.PipelineTask):
         ----------
         exposure : `lsst.afw.image.Exposure`
             Exposure to process.  Only the amplifier DataSec is processed.
-        amp : `lsst.afw.table.AmpInfoCatalog`
+        amp : `lsst.afw.cameraGeom.Amplifier`
             Amplifier detector data.
 
         See Also
@@ -2094,7 +2100,7 @@ class IsrTask(pipeBase.PipelineTask):
         ----------
         exposure : `lsst.afw.image.Exposure`
             Exposure to process.  Only the amplifier DataSec is processed.
-        amp : `lsst.afw.table.AmpInfoCatalog`
+        amp : `lsst.afw.cameraGeom.Amplifier`
             Amplifier detector data.
 
         See Also

--- a/python/lsst/ip/isr/overscan.py
+++ b/python/lsst/ip/isr/overscan.py
@@ -453,7 +453,6 @@ class OverscanCorrectionTask(pipeBase.Task):
         overscanValue = afwMath.makeStatistics(calcImage, fitType, self.statControl).getValue()
 
         return pipeBase.Struct(overscanValue=overscanValue,
-                               maskArray=None,
                                isTransposed=False)
 
     # Vector correction utilities
@@ -475,27 +474,6 @@ class OverscanCorrectionTask(pipeBase.Task):
         else:
             calcImage = image.getArray()
         return calcImage
-
-    @staticmethod
-    def transpose(imageArray):
-        """Transpose input numpy array if necessary.
-
-        Parameters
-        ----------
-        imageArray : `numpy.ndarray`
-            Image data to transpose.
-
-        Returns
-        -------
-        imageArray : `numpy.ndarray`
-            Transposed image data.
-        isTransposed : `bool`
-            Indicates whether the input data was transposed.
-        """
-        if np.argmin(imageArray.shape) == 0:
-            return np.transpose(imageArray), True
-        else:
-            return imageArray, False
 
     def maskOutliers(self, imageArray):
         """Mask  outliers in  a  row  of overscan  data  from  a robust  sigma

--- a/python/lsst/ip/isr/overscan.py
+++ b/python/lsst/ip/isr/overscan.py
@@ -23,6 +23,7 @@ import numpy as np
 import time
 import lsst.afw.math as afwMath
 import lsst.afw.image as afwImage
+import lsst.geom as geom
 import lsst.pipe.base as pipeBase
 import lsst.pex.config as pexConfig
 
@@ -74,6 +75,39 @@ class OverscanCorrectionTaskConfig(pexConfig.Config):
         default=True,
     )
 
+    doParallelOverscan = pexConfig.Field(
+        dtype=bool,
+        doc="Correct using parallel overscan after serial overscan correction?",
+        default=False,
+    )
+
+    leadingColumnsToSkip = pexConfig.Field(
+        dtype=int,
+        doc="Number of leading columns to skip in serial overscan correction.",
+        default=0,
+    )
+    trailingColumnsToSkip = pexConfig.Field(
+        dtype=int,
+        doc="Number of trailing columns to skip in serial overscan correction.",
+        default=0,
+    )
+    leadingRowsToSkip = pexConfig.Field(
+        dtype=int,
+        doc="Number of leading rows to skip in parallel overscan correction.",
+        default=0,
+    )
+    trailingRowsToSkip = pexConfig.Field(
+        dtype=int,
+        doc="Number of trailing rows to skip in parallel overscan correction.",
+        default=0,
+    )
+
+    maxDeviation = pexConfig.Field(
+        dtype=float,
+        doc="Maximum deviation from median (in ADU) to mask in overscan correction.",
+        default=1000.0, check=lambda x: x > 0,
+    )
+
 
 class OverscanCorrectionTask(pipeBase.Task):
     """Correction task for overscan.
@@ -101,7 +135,7 @@ class OverscanCorrectionTask(pipeBase.Task):
             self.statControl.setNumSigmaClip(self.config.numSigmaClip)
             self.statControl.setAndMask(afwImage.Mask.getPlaneBitMask(self.config.maskPlanes))
 
-    def run(self, ampImage, overscanImage, amp=None):
+    def run(self, exposure, amp, isTransposed=False):
         """Measure and remove an overscan from an amplifier image.
 
         Parameters
@@ -134,55 +168,231 @@ class OverscanCorrectionTask(pipeBase.Task):
         ------
         RuntimeError
             Raised if an invalid overscan type is set.
-
         """
+        # Do Serial overscan first.
+        serialOverscanBBox = amp.getRawSerialOverscanBBox()
+        imageBBox = amp.getRawDataBBox()
+
+        if self.config.doParallelOverscan:
+            # We need to extend the serial overscan BBox to the full
+            # size of the detector.
+            parallelOverscanBBox = amp.getRawParallelOverscanBBox()
+            imageBBox = imageBBox.expandedTo(parallelOverscanBBox)
+
+            serialOverscanBBox = geom.Box2I(geom.Point2I(serialOverscanBBox.getMinX(),
+                                                         imageBBox.getMinY()),
+                                            geom.Extent2I(serialOverscanBBox.getWidth(),
+                                                          imageBBox.getHeight()))
+        serialResults = self.correctOverscan(exposure, amp,
+                                             imageBBox, serialOverscanBBox, isTransposed=isTransposed)
+        overscanMean = serialResults.overscanMean
+        overscanSigma = serialResults.overscanSigma
+        residualMean = serialResults.overscanMeanResidual
+        residualSigma = serialResults.overscanSigmaResidual
+
+        # Do Parallel Overscan
+        if self.config.doParallelOverscan:
+            # This does not need any extensions, as we'll only
+            # subtract it from the data region.
+            parallelOverscanBBox = amp.getRawParallelOverscanBBox()
+            imageBBox = amp.getRawDataBBox()
+
+            parallelResults = self.correctOverscan(exposure, amp,
+                                                   imageBBox, parallelOverscanBBox,
+                                                   isTransposed=not isTransposed)
+
+            overscanMean = (overscanMean, parallelResults.overscanMean)
+            overscanSigma = (overscanSigma, parallelResults.overscanSigma)
+            residualMean = (residualMean, parallelResults.overscanMeanResidual)
+            residualSigma = (residualSigma, parallelResults.overscanSigmaResidual)
+
+        return pipeBase.Struct(imageFit=serialResults.ampOverscanModel,
+                               overscanFit=serialResults.overscanOverscanModel,
+                               overscanImage=serialResults.overscanImage,
+
+                               overscanMean=overscanMean,
+                               overscanSigma=overscanSigma,
+                               residualMean=residualMean,
+                               residualSigma=residualSigma)
+
+    def correctOverscan(self, exposure, amp, imageBBox, overscanBBox, isTransposed=True):
+        """
+        """
+        overscanBox = self.trimOverscan(exposure, amp, overscanBBox,
+                                        self.config.leadingColumnsToSkip,
+                                        self.config.trailingColumnsToSkip,
+                                        transpose=isTransposed)
+        overscanImage = exposure[overscanBox].getMaskedImage()
+        overscanArray = overscanImage.image.array
+
+        # Mask pixels.
+        maskVal = overscanImage.mask.getPlaneBitMask(self.config.maskPlanes)
+        overscanMask = ~((overscanImage.mask.array & maskVal) == 0)
+
+        median = np.ma.median(np.ma.masked_where(overscanMask, overscanArray))
+        bad = np.where(np.abs(overscanArray - median) > self.config.maxDeviation)
+        overscanMask[bad] = overscanImage.mask.getPlaneBitMask("SAT")
+
+        # Do overscan fit.
+        # CZW: Handle transposed correctly.
+        overscanResults = self.fitOverscan(overscanImage, isTransposed=isTransposed)
+
+        # Correct image region (and possibly parallel-overscan region).
+        ampImage = exposure[imageBBox]
+        ampOverscanModel = self.broadcastFitToImage(overscanResults.overscanValue,
+                                                    ampImage.image.array,
+                                                    transpose=isTransposed)
+        ampImage.image.array -= ampOverscanModel
+
+        # Correct overscan region (and possibly doubly-overscaned
+        # region).
+        overscanImage = exposure[overscanBBox]
+        # CZW: Transposed?
+        overscanOverscanModel = self.broadcastFitToImage(overscanResults.overscanValue,
+                                                         overscanImage.image.array)
+        overscanImage.image.array -= overscanOverscanModel
+
+        self.debugView(overscanImage, overscanResults.overscanValue, amp)
+
+        # Find residual fit statistics.
+        stats = afwMath.makeStatistics(overscanImage.getMaskedImage(),
+                                       afwMath.MEDIAN | afwMath.STDEVCLIP, self.statControl)
+        residualMean = stats.getValue(afwMath.MEDIAN)
+        residualSigma = stats.getValue(afwMath.STDEVCLIP)
+
+        return pipeBase.Struct(ampOverscanModel=ampOverscanModel,
+                               overscanOverscanModel=overscanOverscanModel,
+                               overscanImage=overscanImage,
+                               overscanValue=overscanResults.overscanValue,
+
+                               overscanMean=overscanResults.overscanMean,
+                               overscanSigma=overscanResults.overscanSigma,
+                               overscanMeanResidual=residualMean,
+                               overscanSigmaResidual=residualSigma
+                               )
+
+    def broadcastFitToImage(self, overscanValue, imageArray, transpose=False):
+        """Broadcast 0 or 1 dimension fit to appropriate shape.
+
+        Parameters
+        ----------
+        overscanValue : `np.ndarray`, (Nrows, ) or scalar
+            Overscan fit to broadcast.
+        imageArray : `np.ndarray`, (Nrows, Ncols)
+            Image array that we want to match.
+        transpose : `bool`, optional
+            Switch order to broadcast along the other axis.
+
+        Returns
+        -------
+        overscanModel : `np.ndarray`, (Nrows, Ncols) or scalar
+            Expanded overscan fit.
+
+        Raises
+        ------
+        RuntimeError
+            Raised if no axis has the appropriate dimension.
+        """
+        if isinstance(overscanValue, np.ndarray):
+            overscanModel = np.zeros_like(imageArray)
+
+            if transpose is False:
+                if imageArray.shape[0] == overscanValue.shape[0]:
+                    overscanModel[:, :] = overscanValue[:, np.newaxis]
+                elif imageArray.shape[1] == overscanValue.shape[0]:
+                    overscanModel[:, :] = overscanValue[np.newaxis, :]
+                elif imageArray.shape[0] == overscanValue.shape[1]:
+                    overscanModel[:, :] = overscanValue[np.newaxis, :]
+                else:
+                    raise RuntimeError(f"Could not broadcast {overscanValue.shape} to "
+                                       f"match {imageArray.shape}")
+            else:
+                if imageArray.shape[1] == overscanValue.shape[0]:
+                    overscanModel[:, :] = overscanValue[np.newaxis, :]
+                elif imageArray.shape[0] == overscanValue.shape[0]:
+                    overscanModel[:, :] = overscanValue[:, np.newaxis]
+                elif imageArray.shape[1] == overscanValue.shape[1]:
+                    overscanModel[:, :] = overscanValue[:, np.newaxis]
+                else:
+                    raise RuntimeError(f"Could not broadcast {overscanValue.shape} to "
+                                       f"match {imageArray.shape}")
+        else:
+            overscanModel = overscanValue
+
+        return overscanModel
+
+    def trimOverscan(self, exposure, amp, bbox, skipLeading, skipTrailing, transpose=False):
+        """Trim overscan region to remove edges.
+
+        Parameters
+        ----------
+        exposure : `lsst.afw.image.Exposure`
+            Exposure containing data.
+        amp : `lsst.afw.cameraGeom.Amplifier`
+            Amplifier containing geometry information.
+        bbox : `lsst.geom.Box2I`
+            Bounding box of the overscan region.
+        skipLeading : `int`
+            Number of leading (towards data region) rows/columns to skip.
+        skipTrailing : `int`
+            Number of trailing (away from data region) rows/columns to skip.
+        transpose : `bool`, optional
+            Operate on the transposed array.
+
+        Returns
+        -------
+        overscanArray : `numpy.array`, (N, M)
+            Data array to fit.
+        overscanMask : `numpy.array`, (N, M)
+            Data mask.
+        """
+        dx0, dy0, dx1, dy1 = (0, 0, 0, 0)
+        dataBBox = amp.getRawDataBBox()
+        if transpose:
+            if dataBBox.getBeginY() < bbox.getBeginY():
+                dy0 += skipLeading
+                dy1 -= skipTrailing
+            else:
+                dy0 += skipTrailing
+                dy1 -= skipLeading
+        else:
+            if dataBBox.getBeginX() < bbox.getBeginX():
+                dx0 += skipLeading
+                dx1 -= skipTrailing
+            else:
+                dx0 += skipTrailing
+                dx1 -= skipLeading
+
+        overscanBBox = geom.Box2I(bbox.getBegin() + geom.Extent2I(dx0, dy0),
+                                  geom.Extent2I(bbox.getWidth() - dx0 + dx1,
+                                                bbox.getHeight() - dy0 + dy1))
+        return overscanBBox
+
+    def fitOverscan(self, overscanImage, isTransposed=False):
         if self.config.fitType in ('MEAN', 'MEANCLIP', 'MEDIAN'):
+            # Transposition has no effect here.
             overscanResult = self.measureConstantOverscan(overscanImage)
             overscanValue = overscanResult.overscanValue
-            offImage = overscanValue
-            overscanModel = overscanValue
-            maskSuspect = None
+            overscanMean = overscanValue
+            overscanSigma = 0.0
         elif self.config.fitType in ('MEDIAN_PER_ROW', 'POLY', 'CHEB', 'LEG',
                                      'NATURAL_SPLINE', 'CUBIC_SPLINE', 'AKIMA_SPLINE'):
-            overscanResult = self.measureVectorOverscan(overscanImage)
+            # Force transposes as needed
+            overscanResult = self.measureVectorOverscan(overscanImage, isTransposed)
             overscanValue = overscanResult.overscanValue
-            maskArray = overscanResult.maskArray
-            isTransposed = overscanResult.isTransposed
 
-            offImage = afwImage.ImageF(ampImage.getDimensions())
-            offArray = offImage.getArray()
-            overscanModel = afwImage.ImageF(overscanImage.getDimensions())
-            overscanArray = overscanModel.getArray()
-
-            if hasattr(ampImage, 'getMask'):
-                maskSuspect = afwImage.Mask(ampImage.getDimensions())
-            else:
-                maskSuspect = None
-
-            if isTransposed:
-                offArray[:, :] = overscanValue[np.newaxis, :]
-                overscanArray[:, :] = overscanValue[np.newaxis, :]
-                if maskSuspect:
-                    maskSuspect.getArray()[:, maskArray] |= ampImage.getMask().getPlaneBitMask("SUSPECT")
-            else:
-                offArray[:, :] = overscanValue[:, np.newaxis]
-                overscanArray[:, :] = overscanValue[:, np.newaxis]
-                if maskSuspect:
-                    maskSuspect.getArray()[maskArray, :] |= ampImage.getMask().getPlaneBitMask("SUSPECT")
+            stats = afwMath.makeStatistics(overscanResult.overscanValue,
+                                           afwMath.MEDIAN | afwMath.STDEVCLIP, self.statControl)
+            overscanMean = stats.getValue(afwMath.MEDIAN)
+            overscanSigma = stats.getValue(afwMath.STDEVCLIP)
         else:
-            raise RuntimeError('%s : %s an invalid overscan type' %
-                               ("overscanCorrection", self.config.fitType))
+            raise ValueError('%s : %s an invalid overscan type' %
+                             ("overscanCorrection", self.config.fitType))
 
-        self.debugView(overscanImage, overscanValue, amp)
-
-        ampImage -= offImage
-        if maskSuspect:
-            ampImage.getMask().getArray()[:, :] |= maskSuspect.getArray()[:, :]
-        overscanImage -= overscanModel
-        return pipeBase.Struct(imageFit=offImage,
-                               overscanFit=overscanModel,
-                               overscanImage=overscanImage,
-                               edgeMask=maskSuspect)
+        return pipeBase.Struct(overscanValue=overscanValue,
+                               overscanMean=overscanMean,
+                               overscanSigma=overscanSigma,
+                               )
 
     @staticmethod
     def integerConvert(image):
@@ -451,7 +661,7 @@ class OverscanCorrectionTask(pipeBase.Task):
                 maskArray[-high:] = True
         return maskArray
 
-    def measureVectorOverscan(self, image):
+    def measureVectorOverscan(self, image, isTransposed=False):
         """Calculate the 1-d vector overscan from the input overscan image.
 
         Parameters
@@ -475,7 +685,8 @@ class OverscanCorrectionTask(pipeBase.Task):
         calcImage = self.getImageArray(image)
 
         # operate on numpy-arrays from here
-        calcImage, isTransposed = self.transpose(calcImage)
+        if isTransposed:
+            calcImage = np.transpose(calcImage)
         masked = self.maskOutliers(calcImage)
 
         startTime = time.perf_counter()
@@ -546,7 +757,8 @@ class OverscanCorrectionTask(pipeBase.Task):
             return
 
         calcImage = self.getImageArray(image)
-        calcImage, isTransposed = self.transpose(calcImage)
+        # CZW: Check that this is ok
+        calcImage = np.transpose(calcImage)
         masked = self.maskOutliers(calcImage)
         collapsed = self.collapseArray(masked)
 

--- a/tests/test_isrTask.py
+++ b/tests/test_isrTask.py
@@ -302,43 +302,6 @@ class IsrTaskUnTrimmedTestCases(lsst.utils.tests.TestCase):
         self.assertIsInstance(results.exposure, afwImage.Exposure)
         return results
 
-    def test_overscanCorrection(self):
-        """Expect that this should reduce the image variance with a full fit.
-        The default fitType of MEDIAN will reduce the median value.
-
-        This needs to operate on a RawMock() to have overscan data to use.
-
-        The output types may be different when fitType != MEDIAN.
-        """
-        statBefore = computeImageMedianAndStd(self.inputExp.image[self.amp.getRawDataBBox()])
-        oscanResults = self.task.overscanCorrection(self.inputExp, self.amp)
-        self.assertIsInstance(oscanResults, Struct)
-        self.assertIsInstance(oscanResults.imageFit, float)
-        self.assertIsInstance(oscanResults.overscanFit, float)
-        self.assertIsInstance(oscanResults.overscanImage, afwImage.MaskedImageF)
-
-        statAfter = computeImageMedianAndStd(self.inputExp.image[self.amp.getRawDataBBox()])
-        self.assertLess(statAfter[0], statBefore[0])
-
-    def test_overscanCorrectionMedianPerRow(self):
-        """Expect that this should reduce the image variance with a full fit.
-        fitType of MEDIAN_PER_ROW will reduce the median value.
-
-        This needs to operate on a RawMock() to have overscan data to use.
-
-        The output types may be different when fitType != MEDIAN_PER_ROW.
-        """
-        self.config.overscan.fitType = 'MEDIAN_PER_ROW'
-        statBefore = computeImageMedianAndStd(self.inputExp.image[self.amp.getRawDataBBox()])
-        oscanResults = self.task.overscanCorrection(self.inputExp, self.amp)
-        self.assertIsInstance(oscanResults, Struct)
-        self.assertIsInstance(oscanResults.imageFit, afwImage.ImageF)
-        self.assertIsInstance(oscanResults.overscanFit, afwImage.ImageF)
-        self.assertIsInstance(oscanResults.overscanImage, afwImage.MaskedImageF)
-
-        statAfter = computeImageMedianAndStd(self.inputExp.image[self.amp.getRawDataBBox()])
-        self.assertLess(statAfter[0], statBefore[0])
-
     def test_run_allTrue(self):
         """Expect successful run with expected outputs when all non-exclusive
         configuration options are on.
@@ -379,8 +342,8 @@ class IsrTaskUnTrimmedTestCases(lsst.utils.tests.TestCase):
         """Test masking cases of configuration parameters.
         """
         self.batchSetConfiguration(True)
-        self.config.overscanFitType = "POLY"
-        self.config.overscanOrder = 1
+        self.config.overscan.fitType = "POLY"
+        self.config.overscan.order = 1
 
         self.config.doSaturation = False
         self.config.doWidenSaturationTrails = False
@@ -404,8 +367,8 @@ class IsrTaskUnTrimmedTestCases(lsst.utils.tests.TestCase):
         """Test masking cases of configuration parameters.
         """
         self.batchSetConfiguration(True)
-        self.config.overscanFitType = "POLY"
-        self.config.overscanOrder = 1
+        self.config.overscan.fitType = "POLY"
+        self.config.overscan.order = 1
 
         self.config.doSaturation = False
         self.config.doWidenSaturationTrails = False
@@ -429,8 +392,8 @@ class IsrTaskUnTrimmedTestCases(lsst.utils.tests.TestCase):
         """Test masking cases of configuration parameters.
         """
         self.batchSetConfiguration(True)
-        self.config.overscanFitType = "POLY"
-        self.config.overscanOrder = 1
+        self.config.overscan.fitType = "POLY"
+        self.config.overscan.order = 1
 
         self.config.saturation = 20000.0
         self.config.doSaturation = True
@@ -455,8 +418,8 @@ class IsrTaskUnTrimmedTestCases(lsst.utils.tests.TestCase):
         """Test masking cases of configuration parameters.
         """
         self.batchSetConfiguration(True)
-        self.config.overscanFitType = "POLY"
-        self.config.overscanOrder = 1
+        self.config.overscan.fitType = "POLY"
+        self.config.overscan.order = 1
 
         self.config.saturation = 20000.0
         self.config.doSaturation = True
@@ -481,8 +444,8 @@ class IsrTaskUnTrimmedTestCases(lsst.utils.tests.TestCase):
         """Test masking cases of configuration parameters.
         """
         self.batchSetConfiguration(True)
-        self.config.overscanFitType = "POLY"
-        self.config.overscanOrder = 1
+        self.config.overscan.fitType = "POLY"
+        self.config.overscan.order = 1
 
         self.config.saturation = 20000.0
         self.config.doSaturation = True
@@ -508,8 +471,8 @@ class IsrTaskUnTrimmedTestCases(lsst.utils.tests.TestCase):
         """Test masking cases of configuration parameters.
         """
         self.batchSetConfiguration(True)
-        self.config.overscanFitType = "POLY"
-        self.config.overscanOrder = 1
+        self.config.overscan.fitType = "POLY"
+        self.config.overscan.order = 1
 
         self.config.saturation = 20000.0
         self.config.doSaturation = True
@@ -535,8 +498,8 @@ class IsrTaskUnTrimmedTestCases(lsst.utils.tests.TestCase):
         """Test masking cases of configuration parameters.
         """
         self.batchSetConfiguration(True)
-        self.config.overscanFitType = "POLY"
-        self.config.overscanOrder = 1
+        self.config.overscan.fitType = "POLY"
+        self.config.overscan.order = 1
 
         self.config.saturation = 20000.0
         self.config.doSaturation = True
@@ -563,8 +526,8 @@ class IsrTaskUnTrimmedTestCases(lsst.utils.tests.TestCase):
         """Test masking cases of configuration parameters.
         """
         self.batchSetConfiguration(True)
-        self.config.overscanFitType = "POLY"
-        self.config.overscanOrder = 1
+        self.config.overscan.fitType = "POLY"
+        self.config.overscan.order = 1
 
         self.config.saturation = 20000.0
         self.config.doSaturation = True
@@ -596,4 +559,4 @@ def setup_module(module):
 
 if __name__ == "__main__":
     lsst.utils.tests.init()
-    unittest.main()
+    unittest.main(failfast=True)


### PR DESCRIPTION
* Remove isrFunction intermediate for overscan correction.
* Add support for parallel overscan correction.
* Fix handling of column/row skipping, to ensure that overscan result is subtracted where needed.
* Consolidate unit tests for overscan correction in one location.