### PR TITLE
DM-22823: Remove accidental Doxygen comments for namespaces

### DIFF
--- a/doc/doxygen.conf.in
+++ b/doc/doxygen.conf.in
@@ -1,1 +1,1 @@
-EXAMPLE_PATH = examples python/lsst/ip/isr
+# Empty file needed by build system, see DM-35793.

--- a/include/lsst/ip/isr/isr.h
+++ b/include/lsst/ip/isr/isr.h
@@ -22,14 +22,10 @@
  * see <http://www.lsstcorp.org/LegalNotices/>.
  */
 
-/**
-  * \file
-  *
-  * \ingroup isr
-  *
-  * \brief Implementation of the templated Instrument Signature Removal
-  * stage of the nightly LSST Image Processing Pipeline.
-  */
+/*
+ * Implementation of the templated Instrument Signature Removal
+ * stage of the nightly LSST Image Processing Pipeline.
+ */
 
 #ifndef LSST_IP_ISR_ISR_H
 #define LSST_IP_ISR_ISR_H
@@ -44,14 +40,13 @@
 #include "lsst/afw/image.h"
 #include "lsst/pex/exceptions/Exception.h"
 
-/** \brief Remove all non-astronomical counts from the Chunk Exposure's pixels.
-  *
-  */
-
 namespace lsst {
 namespace ip {
 namespace isr {
 
+    /**
+     * Remove all non-astronomical counts from the Chunk Exposure's pixels.
+     */
     template <typename ImageT, typename MaskT=lsst::afw::image::MaskPixel>
     class CountMaskedPixels {
     public:

--- a/python/lsst/ip/isr/assembleCcdTask.py
+++ b/python/lsst/ip/isr/assembleCcdTask.py
@@ -44,7 +44,7 @@ class AssembleCcdConfig(pexConfig.Config):
 
 ## @addtogroup LSST_task_documentation
 ## @{
-## @page AssembleCcdTask
+## @page page_AssembleCcdTask AssembleCcdTask
 ## @ref AssembleCcdTask_ "AssembleCcdTask"
 ## @copybrief AssembleCcdTask
 ## @}
@@ -79,7 +79,7 @@ class AssembleCcdTask(pipeBase.Task):
 
     @section ip_isr_assemble_Initialize Task initialization
 
-    @copydoc \_\_init\_\_
+    @copydoc __init__
 
     @section ip_isr_assemble_IO Inputs/Outputs to the assembleCcd method
 
@@ -91,8 +91,7 @@ class AssembleCcdTask(pipeBase.Task):
 
     @section ip_isr_assemble_Debug Debug variables
 
-    The @link lsst.pipe.base.cmdLineTask.CmdLineTask command line task@endlink
-    interface supports a flag @c -d to import @b debug.py from your
+    The command line task interface supports a flag @c -d to import @b debug.py from your
     @c PYTHONPATH; see <a
     href="https://developer.lsst.io/stack/debug.html">Debugging Tasks with
     lsstDebug</a> for more about @b debug.py files.


### PR DESCRIPTION
This PR removes or rearranges Doxygen comments that were intended to be file-level (or, in one case, block-level) but instead described namespaces, and also fixes some Doxygen warnings discovered during testing.