### PR TITLE
DM-35569: ip_isr doEmpiricalReadNoise fails if an amplifier is fully masked

### DIFF
--- a/python/lsst/ip/isr/isrFunctions.py
+++ b/python/lsst/ip/isr/isrFunctions.py
@@ -26,6 +26,7 @@ __all__ = [
     "biasCorrection",
     "brighterFatterCorrection",
     "checkFilter",
+    "countMaskedPixels",
     "createPsf",
     "darkCorrection",
     "flatCorrection",
@@ -896,3 +897,23 @@ def getPhysicalFilter(filterLabel, log):
             log.warning("filterLabel has no physicalLabel attribute.  Setting physicalFilter to \"Unknown\".")
             physicalFilter = "Unknown"
     return physicalFilter
+
+
+def countMaskedPixels(maskedIm, maskPlane):
+    """Count the number of pixels in a given mask plane.
+
+    Parameters
+    ----------
+    maskedIm : `~lsst.afw.image.MaskedImage`
+        Masked image to examine.
+    maskPlane : `str`
+        Name of the mask plane to examine.
+
+    Returns
+    -------
+    nPix : `int`
+        Number of pixels in the requested mask plane.
+    """
+    maskBit = maskedIm.mask.getPlaneBitMask(maskPlane)
+    nPix = numpy.where(numpy.bitwise_and(maskedIm.mask.array, maskBit))[0].flatten().size
+    return nPix

--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -1839,7 +1839,17 @@ class IsrTask(pipeBase.PipelineTask):
             gain = patchedGain
 
         if self.config.doEmpiricalReadNoise and overscanImage is None:
-            raise RuntimeError("Overscan is none for EmpiricalReadNoise.")
+            badPixels = isrFunctions.countMaskedPixels(ampExposure.getMaskedImage(),
+                                                       [self.config.saturatedMaskName,
+                                                        self.config.suspectMaskName,
+                                                        "BAD", "NO_DATA"])
+            allPixels = ampExposure.getWidth() * ampExposure.getHeight()
+            if allPixels == badPixels:
+                # If the image is bad, do not raise.
+                self.log.info("Skipping empirical read noise for amp %s.  No good pixels.",
+                              amp.getName())
+            else:
+                raise RuntimeError("Overscan is none for EmpiricalReadNoise.")
 
         if self.config.doEmpiricalReadNoise and overscanImage is not None:
             stats = afwMath.StatisticsControl()


### PR DESCRIPTION
Move countMaskedPixels from cp_pipe, and use it to check that the amplifier is fully masked.