### PR TITLE
DM-37357: Update masking in parallel overscan

### DIFF
--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -1300,26 +1300,8 @@ class IsrTask(pipeBase.PipelineTask):
         overscans = []
 
         if self.config.doOverscan and self.config.overscan.doParallelOverscan:
-            parallelMask = None
-
-            for amp in ccd:
-                dataView = afwImage.MaskedImageF(ccdExposure.getMaskedImage(),
-                                                 amp.getRawParallelOverscanBBox(),
-                                                 afwImage.PARENT)
-
-                isrFunctions.makeThresholdMask(
-                    maskedImage=dataView, threshold=100000,
-                    growFootprints=2, maskName="BAD"
-                )
-                if parallelMask is None:
-                    parallelMask = dataView.mask.array
-                else:
-                    parallelMask |= dataView.mask.array
-            for amp in ccd:
-                dataView = afwImage.MaskedImageF(ccdExposure.getMaskedImage(),
-                                                 amp.getRawParallelOverscanBBox(),
-                                                 afwImage.PARENT)
-                dataView.mask.array |= parallelMask
+            # This will attempt to mask bleed pixels across all amplifiers.
+            self.overscan.maskParallelOverscan(ccdExposure, ccd)
 
         for amp in ccd:
             # if ccdExposure is one amp,

--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -1309,7 +1309,7 @@ class IsrTask(pipeBase.PipelineTask):
 
                 isrFunctions.makeThresholdMask(
                     maskedImage=dataView, threshold=100000,
-                    growFootprints=0, maskName="BAD"
+                    growFootprints=2, maskName="BAD"
                 )
                 if parallelMask is None:
                     parallelMask = dataView.mask.array
@@ -1907,7 +1907,6 @@ class IsrTask(pipeBase.PipelineTask):
         See Also
         --------
         lsst.ip.isr.overscan.OverscanTask
-
         """
         if amp.getRawHorizontalOverscanBBox().isEmpty():
             self.log.info("ISR_OSCAN: No overscan region.  Not performing overscan correction.")

--- a/python/lsst/ip/isr/overscan.py
+++ b/python/lsst/ip/isr/overscan.py
@@ -577,12 +577,8 @@ class OverscanCorrectionTask(pipeBase.Task):
             - ``overscanValue``: Overscan value to subtract (`float`)
             - ``isTransposed``: Orientation of the overscan (`bool`)
         """
-        if self.config.fitType == 'MEDIAN':
-            calcImage = self.integerConvert(image)
-        else:
-            calcImage = image
         fitType = afwMath.stringToStatisticsProperty(self.config.fitType)
-        overscanValue = afwMath.makeStatistics(calcImage, fitType, self.statControl).getValue()
+        overscanValue = afwMath.makeStatistics(image, fitType, self.statControl).getValue()
 
         return pipeBase.Struct(overscanValue=overscanValue,
                                isTransposed=False)


### PR DESCRIPTION
This update switches from a fractional-based masking that turns the parallel overscan correction on and off to a fixed threshold based mask that attempts to patch the fully masked columns from unmasked columns.  The mask generated from the threshold is applied across all amplifiers, to ensure crosstalk ghosts of the original bright bleed are also excluded from the calculations.