### PR TITLE
DM-38163: Update PTC to avoid potential failures

### DIFF
--- a/python/lsst/ip/isr/ptcDataset.py
+++ b/python/lsst/ip/isr/ptcDataset.py
@@ -300,6 +300,7 @@ class PhotonTransferCurveDataset(IsrCalib):
         calib.ptcFitType = dictionary['ptcFitType']
         calib.covMatrixSide = dictionary['covMatrixSide']
         calib.badAmps = np.array(dictionary['badAmps'], 'str').tolist()
+        calib.ampNames = []
 
         # The cov matrices are square
         covMatrixSide = calib.covMatrixSide


### PR DESCRIPTION
Fix error that allowed duplicate PTC ampNames.