### PR TITLE
DM-38535: Fix PhotonTransferCurveDataset types for scalar quantities

### DIFF
--- a/python/lsst/ip/isr/ptcDataset.py
+++ b/python/lsst/ip/isr/ptcDataset.py
@@ -323,36 +323,43 @@ class PhotonTransferCurveDataset(IsrCalib):
             calib.ampNames.append(ampName)
             calib.inputExpIdPairs[ampName] = dictionary['inputExpIdPairs'][ampName]
             calib.expIdMask[ampName] = np.array(dictionary['expIdMask'][ampName])
-            calib.rawExpTimes[ampName] = np.array(dictionary['rawExpTimes'][ampName])
-            calib.rawMeans[ampName] = np.array(dictionary['rawMeans'][ampName])
-            calib.rawVars[ampName] = np.array(dictionary['rawVars'][ampName])
-            calib.gain[ampName] = np.array(dictionary['gain'][ampName])
-            calib.gainErr[ampName] = np.array(dictionary['gainErr'][ampName])
-            calib.noise[ampName] = np.array(dictionary['noise'][ampName])
-            calib.noiseErr[ampName] = np.array(dictionary['noiseErr'][ampName])
-            calib.ptcFitPars[ampName] = np.array(dictionary['ptcFitPars'][ampName])
-            calib.ptcFitParsError[ampName] = np.array(dictionary['ptcFitParsError'][ampName])
-            calib.ptcFitChiSq[ampName] = np.array(dictionary['ptcFitChiSq'][ampName])
-            calib.ptcTurnoff[ampName] = np.array(dictionary['ptcTurnoff'][ampName])
+            calib.rawExpTimes[ampName] = np.array(dictionary['rawExpTimes'][ampName], dtype=np.float64)
+            calib.rawMeans[ampName] = np.array(dictionary['rawMeans'][ampName], dtype=np.float64)
+            calib.rawVars[ampName] = np.array(dictionary['rawVars'][ampName], dtype=np.float64)
+            calib.gain[ampName] = float(dictionary['gain'][ampName])
+            calib.gainErr[ampName] = float(dictionary['gainErr'][ampName])
+            calib.noise[ampName] = float(dictionary['noise'][ampName])
+            calib.noiseErr[ampName] = float(dictionary['noiseErr'][ampName])
+            calib.ptcFitPars[ampName] = np.array(dictionary['ptcFitPars'][ampName], dtype=np.float64)
+            calib.ptcFitParsError[ampName] = np.array(dictionary['ptcFitParsError'][ampName],
+                                                      dtype=np.float64)
+            calib.ptcFitChiSq[ampName] = float(dictionary['ptcFitChiSq'][ampName])
+            calib.ptcTurnoff[ampName] = float(dictionary['ptcTurnoff'][ampName])
             if nSignalPoints > 0:
                 # Regular dataset
-                calib.covariances[ampName] = np.array(dictionary['covariances'][ampName]).reshape(
+                calib.covariances[ampName] = np.array(dictionary['covariances'][ampName],
+                                                      dtype=np.float64).reshape(
                     (nSignalPoints, covMatrixSide, covMatrixSide))
                 calib.covariancesModel[ampName] = np.array(
-                    dictionary['covariancesModel'][ampName]).reshape(
+                    dictionary['covariancesModel'][ampName],
+                    dtype=np.float64).reshape(
                         (nSignalPoints, covMatrixSide, covMatrixSide))
                 calib.covariancesSqrtWeights[ampName] = np.array(
-                    dictionary['covariancesSqrtWeights'][ampName]).reshape(
+                    dictionary['covariancesSqrtWeights'][ampName],
+                    dtype=np.float64).reshape(
                         (nSignalPoints, covMatrixSide, covMatrixSide))
-                calib.aMatrix[ampName] = np.array(dictionary['aMatrix'][ampName]).reshape(
+                calib.aMatrix[ampName] = np.array(dictionary['aMatrix'][ampName],
+                                                  dtype=np.float64).reshape(
                     (covMatrixSide, covMatrixSide))
-                calib.bMatrix[ampName] = np.array(dictionary['bMatrix'][ampName]).reshape(
+                calib.bMatrix[ampName] = np.array(dictionary['bMatrix'][ampName],
+                                                  dtype=np.float64).reshape(
                     (covMatrixSide, covMatrixSide))
                 calib.covariancesModelNoB[ampName] = np.array(
-                    dictionary['covariancesModelNoB'][ampName]).reshape(
+                    dictionary['covariancesModelNoB'][ampName], dtype=np.float64).reshape(
                         (nSignalPoints, covMatrixSide, covMatrixSide))
                 calib.aMatrixNoB[ampName] = np.array(
-                    dictionary['aMatrixNoB'][ampName]).reshape((covMatrixSide, covMatrixSide))
+                    dictionary['aMatrixNoB'][ampName],
+                    dtype=np.float64).reshape((covMatrixSide, covMatrixSide))
             else:
                 # Empty dataset
                 calib.covariances[ampName] = np.array([], dtype=np.float64)
@@ -363,10 +370,10 @@ class PhotonTransferCurveDataset(IsrCalib):
                 calib.covariancesModelNoB[ampName] = np.array([], dtype=np.float64)
                 calib.aMatrixNoB[ampName] = np.array([], dtype=np.float64)
 
-            calib.finalVars[ampName] = np.array(dictionary['finalVars'][ampName])
-            calib.finalModelVars[ampName] = np.array(dictionary['finalModelVars'][ampName])
-            calib.finalMeans[ampName] = np.array(dictionary['finalMeans'][ampName])
-            calib.photoCharges[ampName] = np.array(dictionary['photoCharges'][ampName])
+            calib.finalVars[ampName] = np.array(dictionary['finalVars'][ampName], dtype=np.float64)
+            calib.finalModelVars[ampName] = np.array(dictionary['finalModelVars'][ampName], dtype=np.float64)
+            calib.finalMeans[ampName] = np.array(dictionary['finalMeans'][ampName], dtype=np.float64)
+            calib.photoCharges[ampName] = np.array(dictionary['photoCharges'][ampName], dtype=np.float64)
 
         calib.updateMetadata()
         return calib

--- a/tests/test_ptcDataset.py
+++ b/tests/test_ptcDataset.py
@@ -75,22 +75,69 @@ class PtcDatasetCases(lsst.utils.tests.TestCase):
             self.dataset.rawMeans[ampName] = muVec
             self.covariancesSqrtWeights[ampName] = []
 
+    def _checkTypes(self, ptcDataset):
+        """Check that all the types are correct for a ptc dataset."""
+        for ampName in ptcDataset.ampNames:
+            self.assertIsInstance(ptcDataset.expIdMask[ampName], np.ndarray)
+            self.assertEqual(ptcDataset.expIdMask[ampName].dtype, bool)
+            self.assertIsInstance(ptcDataset.rawExpTimes[ampName], np.ndarray)
+            self.assertEqual(ptcDataset.rawExpTimes[ampName].dtype, np.float64)
+            self.assertIsInstance(ptcDataset.rawMeans[ampName], np.ndarray)
+            self.assertEqual(ptcDataset.rawMeans[ampName].dtype, np.float64)
+            self.assertIsInstance(ptcDataset.rawVars[ampName], np.ndarray)
+            self.assertEqual(ptcDataset.rawVars[ampName].dtype, np.float64)
+            self.assertIsInstance(ptcDataset.gain[ampName], float)
+            self.assertIsInstance(ptcDataset.gainErr[ampName], float)
+            self.assertIsInstance(ptcDataset.noise[ampName], float)
+            self.assertIsInstance(ptcDataset.noiseErr[ampName], float)
+            self.assertIsInstance(ptcDataset.ptcFitPars[ampName], np.ndarray)
+            self.assertEqual(ptcDataset.ptcFitPars[ampName].dtype, np.float64)
+            self.assertIsInstance(ptcDataset.ptcFitParsError[ampName], np.ndarray)
+            self.assertEqual(ptcDataset.ptcFitParsError[ampName].dtype, np.float64)
+            self.assertIsInstance(ptcDataset.ptcFitChiSq[ampName], float)
+            self.assertIsInstance(ptcDataset.ptcTurnoff[ampName], float)
+            self.assertIsInstance(ptcDataset.covariances[ampName], np.ndarray)
+            self.assertEqual(ptcDataset.covariances[ampName].dtype, np.float64)
+            self.assertIsInstance(ptcDataset.covariancesModel[ampName], np.ndarray)
+            self.assertEqual(ptcDataset.covariancesModel[ampName].dtype, np.float64)
+            self.assertIsInstance(ptcDataset.covariancesSqrtWeights[ampName], np.ndarray)
+            self.assertEqual(ptcDataset.covariancesSqrtWeights[ampName].dtype, np.float64)
+            self.assertIsInstance(ptcDataset.aMatrix[ampName], np.ndarray)
+            self.assertEqual(ptcDataset.aMatrix[ampName].dtype, np.float64)
+            self.assertIsInstance(ptcDataset.bMatrix[ampName], np.ndarray)
+            self.assertEqual(ptcDataset.bMatrix[ampName].dtype, np.float64)
+            self.assertIsInstance(ptcDataset.covariancesModelNoB[ampName], np.ndarray)
+            self.assertEqual(ptcDataset.covariancesModelNoB[ampName].dtype, np.float64)
+            self.assertIsInstance(ptcDataset.aMatrixNoB[ampName], np.ndarray)
+            self.assertEqual(ptcDataset.aMatrixNoB[ampName].dtype, np.float64)
+            self.assertIsInstance(ptcDataset.finalVars[ampName], np.ndarray)
+            self.assertEqual(ptcDataset.finalVars[ampName].dtype, np.float64)
+            self.assertIsInstance(ptcDataset.finalModelVars[ampName], np.ndarray)
+            self.assertEqual(ptcDataset.finalModelVars[ampName].dtype, np.float64)
+            self.assertIsInstance(ptcDataset.finalMeans[ampName], np.ndarray)
+            self.assertEqual(ptcDataset.finalMeans[ampName].dtype, np.float64)
+            self.assertIsInstance(ptcDataset.photoCharges[ampName], np.ndarray)
+            self.assertEqual(ptcDataset.photoCharges[ampName].dtype, np.float64)
+
     def test_emptyPtcDataset(self):
         """Test an empty PTC dataset."""
         emptyDataset = PhotonTransferCurveDataset(
             self.ampNames,
             ptcFitType="PARTIAL",
         )
+        self._checkTypes(emptyDataset)
 
         with tempfile.NamedTemporaryFile(suffix=".yaml") as f:
             usedFilename = emptyDataset.writeText(f.name)
             fromText = PhotonTransferCurveDataset.readText(usedFilename)
         self.assertEqual(emptyDataset, fromText)
+        self._checkTypes(emptyDataset)
 
         with tempfile.NamedTemporaryFile(suffix=".fits") as f:
             usedFilename = emptyDataset.writeFits(f.name)
             fromFits = PhotonTransferCurveDataset.readFits(usedFilename)
         self.assertEqual(emptyDataset, fromFits)
+        self._checkTypes(emptyDataset)
 
     def test_partialPtcDataset(self):
         """Test of a partial PTC dataset."""
@@ -102,6 +149,7 @@ class PtcDatasetCases(lsst.utils.tests.TestCase):
             ptcFitType="PARTIAL",
             covMatrixSide=nSideCovMatrix
         )
+        self._checkTypes(partialDataset)
 
         for ampName in partialDataset.ampNames:
             partialDataset.setAmpValuesPartialDataset(
@@ -111,16 +159,19 @@ class PtcDatasetCases(lsst.utils.tests.TestCase):
                 rawMean=10.0,
                 rawVar=10.0,
             )
+        self._checkTypes(partialDataset)
 
         with tempfile.NamedTemporaryFile(suffix=".yaml") as f:
             usedFilename = partialDataset.writeText(f.name)
             fromText = PhotonTransferCurveDataset.readText(usedFilename)
-        self.assertEqual(partialDataset, fromText)
+        self.assertEqual(fromText, partialDataset)
+        self._checkTypes(fromText)
 
         with tempfile.NamedTemporaryFile(suffix=".fits") as f:
             usedFilename = partialDataset.writeFits(f.name)
             fromFits = PhotonTransferCurveDataset.readFits(usedFilename)
-        self.assertEqual(partialDataset, fromFits)
+        self.assertEqual(fromFits, partialDataset)
+        self._checkTypes(fromFits)
 
     def test_ptcDatset(self):
         """Test of a full PTC dataset."""
@@ -139,7 +190,7 @@ class PtcDatasetCases(lsst.utils.tests.TestCase):
                 localDataset.inputExpIdPairs[ampName] = [(1, 2)]*nSignalPoints
                 localDataset.expIdMask[ampName] = np.ones(nSignalPoints, dtype=bool)
                 localDataset.expIdMask[ampName][1] = False
-                localDataset.rawExpTimes[ampName] = np.arange(nSignalPoints)
+                localDataset.rawExpTimes[ampName] = np.arange(nSignalPoints, dtype=np.float64)
                 localDataset.rawMeans[ampName] = self.flux*np.arange(nSignalPoints)
                 localDataset.rawVars[ampName] = self.c1*self.flux*np.arange(nSignalPoints)
                 localDataset.photoCharges[ampName] = np.full(nSignalPoints, np.nan)
@@ -174,8 +225,8 @@ class PtcDatasetCases(lsst.utils.tests.TestCase):
                 if localDataset.ptcFitType in ['FULLCOVARIANCE', ]:
                     localDataset.ptcFitPars[ampName] = np.array([np.nan, np.nan])
                     localDataset.ptcFitParsError[ampName] = np.array([np.nan, np.nan])
-                    localDataset.ptcFitChiSq[ampName] = np.array([np.nan, np.nan])
-                    localDataset.ptcTurnoff[ampName] = np.array([np.nan, np.nan])
+                    localDataset.ptcFitChiSq[ampName] = np.nan
+                    localDataset.ptcTurnoff[ampName] = np.nan
 
                     localDataset.covariances[ampName] = np.full(
                         (nSignalPoints, nSideCovMatrix, nSideCovMatrix), 105.0)
@@ -190,15 +241,19 @@ class PtcDatasetCases(lsst.utils.tests.TestCase):
                     localDataset.aMatrixNoB[ampName] = np.full(
                         (nSideCovMatrix, nSideCovMatrix), 2e-6)
 
+            self._checkTypes(localDataset)
+
             with tempfile.NamedTemporaryFile(suffix=".yaml") as f:
                 usedFilename = localDataset.writeText(f.name)
                 fromText = PhotonTransferCurveDataset.readText(usedFilename)
-            self.assertEqual(localDataset, fromText)
+            self.assertEqual(fromText, localDataset)
+            self._checkTypes(fromText)
 
             with tempfile.NamedTemporaryFile(suffix=".fits") as f:
                 usedFilename = localDataset.writeFits(f.name)
                 fromFits = PhotonTransferCurveDataset.readFits(usedFilename)
-            self.assertEqual(localDataset, fromFits)
+            self.assertEqual(fromFits, localDataset)
+            self._checkTypes(fromFits)
 
     def test_getExpIdsUsed(self):
         localDataset = copy.copy(self.dataset)


### PR DESCRIPTION
This PR adds tests and fixes inconsistencies between the data types for all the components of the PhotonTransferCurveDataset.  Note that the explicit conversions to `np.float64` are needed because FITS serialization can swap byte order, and this will ensure consistent byte ordering in case anything needs that.