### PR TITLE
DM-39338: flatten arrays in photodiode calibration

### DIFF
--- a/python/lsst/ip/isr/photodiode.py
+++ b/python/lsst/ip/isr/photodiode.py
@@ -65,11 +65,11 @@ class PhotodiodeCalib(IsrCalib):
             if len(timeSamples) != len(currentSamples):
                 raise RuntimeError(f"Inconsitent vector lengths: {len(timeSamples)} vs {len(currentSamples)}")
             else:
-                self.timeSamples = np.array(timeSamples).flatten()
-                self.currentSamples = np.array(currentSamples).flatten()
+                self.timeSamples = np.array(timeSamples).ravel()
+                self.currentSamples = np.array(currentSamples).ravel()
         else:
-            self.timeSamples = np.array([]).flatten()
-            self.currentSamples = np.array([]).flatten()
+            self.timeSamples = np.array([]).ravel()
+            self.currentSamples = np.array([]).ravel()
 
         super().__init__(**kwargs)
 
@@ -118,8 +118,8 @@ class PhotodiodeCalib(IsrCalib):
 
         calib.setMetadata(dictionary['metadata'])
 
-        calib.timeSamples = np.array(dictionary['timeSamples']).flatten()
-        calib.currentSamples = np.array(dictionary['currentSamples']).flatten()
+        calib.timeSamples = np.array(dictionary['timeSamples']).ravel()
+        calib.currentSamples = np.array(dictionary['currentSamples']).ravel()
         calib.integrationMethod = dictionary.get('integrationMethod', "DIRECT_SUM")
 
         calib.updateMetadata()

--- a/tests/test_photodiode.py
+++ b/tests/test_photodiode.py
@@ -63,6 +63,10 @@ class PhotodiodeTestCase(lsst.utils.tests.TestCase):
         self.assertFloatsAlmostEqual(calib.integrate(), 2.88414e-10, rtol=1e-14)
         self.assertFloatsAlmostEqual(calib.integrateDirectSum(), 2.88414e-10, rtol=1e-14)
         self.assertFloatsAlmostEqual(calib.integrateTrimmedSum(), 2.88720e-10, rtol=1e-14)
+        self.assertFloatsAlmostEqual(calib.integrateChargeSum(), 3.5978848e-09, rtol=1e-14)
+
+        self.assertEqual(calib.timeSamples.shape, (16, ))
+        self.assertEqual(calib.currentSamples.shape, (16, ))
 
         outPath = tempfile.mktemp() + '.yaml'
         calib.writeText(outPath)
@@ -83,6 +87,10 @@ class PhotodiodeTestCase(lsst.utils.tests.TestCase):
         self.assertFloatsAlmostEqual(calib.integrate(), 2.88414e-10, rtol=1e-14)
         self.assertFloatsAlmostEqual(calib.integrateDirectSum(), 2.88414e-10, rtol=1e-14)
         self.assertFloatsAlmostEqual(calib.integrateTrimmedSum(), 2.88720e-10, rtol=1e-14)
+        self.assertFloatsAlmostEqual(calib.integrateChargeSum(), 3.5978848e-09, rtol=1e-14)
+
+        self.assertEqual(calib.timeSamples.shape, (16, ))
+        self.assertEqual(calib.currentSamples.shape, (16, ))
 
         outPath = tempfile.mktemp() + '.yaml'
         calib.writeText(outPath)


### PR DESCRIPTION
Flatten arrays, and remove 2d indexing in integrateChargeSum.
Add unit tests for array shape, and for integrateChargeSum return values.