### PR TITLE
DM-40094  Convolution control edge copy method results in diverging correction in fluxConservingBrighterFatterCorrection

### DIFF
--- a/python/lsst/ip/isr/isrFunctions.py
+++ b/python/lsst/ip/isr/isrFunctions.py
@@ -785,7 +785,7 @@ def fluxConservingBrighterFatterCorrection(exposure, kernel, maxIter, threshold,
         outImage = afwImage.ImageF(image.getDimensions())
         corr = numpy.zeros_like(image.getArray())
         prevImage = numpy.zeros_like(image.getArray())
-        convCntrl = afwMath.ConvolutionControl(False, True, 1)
+        convCntrl = afwMath.ConvolutionControl(False, False, 1)
         fixedKernel = afwMath.FixedKernel(kernelImage)
 
         # set the padding amount

--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -1525,7 +1525,7 @@ class IsrTask(pipeBase.PipelineTask):
                     self.config.brighterFatterApplyGain,
                     bfGains
                 )
-            if bfResults[1] == self.config.brighterFatterMaxIter:
+            if bfResults[1] == self.config.brighterFatterMaxIter - 1:
                 self.log.warning("Brighter-fatter correction did not converge, final difference %f.",
                                  bfResults[0])
             else:


### PR DESCRIPTION
I've also folded in the change from youtsumi:u/youtsumi/DM-40049 to fix the max iteration log message.