### PR TITLE
DM-36647: First draft of new isr task 

### DIFF
--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -25,43 +25,6 @@ from .masking import MaskingTask
 from .isrStatistics import IsrStatisticsTask
 from .isr import maskNans
 
-
-def crosstalkSourceLookup(datasetType, registry, quantumDataId, collections):
-    """Lookup function to identify crosstalkSource entries.
-
-    This should return an empty list under most circumstances.  Only
-    when inter-chip crosstalk has been identified should this be
-    populated.
-
-    Parameters
-    ----------
-    datasetType : `str`
-        Dataset to lookup.
-    registry : `lsst.daf.butler.Registry`
-        Butler registry to query.
-    quantumDataId : `lsst.daf.butler.ExpandedDataCoordinate`
-        Data id to transform to identify crosstalkSources.  The
-        ``detector`` entry will be stripped.
-    collections : `lsst.daf.butler.CollectionSearch`
-        Collections to search through.
-
-    Returns
-    -------
-    results : `list` [`lsst.daf.butler.DatasetRef`]
-        List of datasets that match the query that will be used as
-        crosstalkSources.
-    """
-    newDataId = quantumDataId.subset(DimensionGraph(registry.dimensions, names=["instrument", "exposure"]))
-    results = set(registry.queryDatasets(datasetType, collections=collections, dataId=newDataId,
-                                         findFirst=True))
-    # In some contexts, calling `.expanded()` to expand all data IDs in the
-    # query results can be a lot faster because it vectorizes lookups.  But in
-    # this case, expandDataId shouldn't need to hit the database at all in the
-    # steady state, because only the detector record is unknown and those are
-    # cached in the registry.
-    return [ref.expanded(registry.expandDataId(ref.dataId, records=newDataId.records)) for ref in results]
-
-
 class IsrTaskLSSTConnections(pipeBase.PipelineTaskConnections,
                              dimensions={"instrument", "exposure", "detector"},
                              defaultTemplates={}):
@@ -120,16 +83,6 @@ class IsrTaskLSSTConnections(pipeBase.PipelineTaskConnections,
         storageClass="CrosstalkCalib",
         dimensions=["instrument", "detector"],
         isCalibration=True,
-    )
-    crosstalkSources = cT.PrerequisiteInput(
-        name="isrOverscanCorrected",
-        doc="Overscan corrected input images.",
-        storageClass="Exposure",
-        dimensions=["instrument", "exposure", "detector"],
-        deferLoad=True,
-        multiple=True,
-        lookupFunction=crosstalkSourceLookup,
-        minimum=0,  # not needed for all instruments, no config to control this
     )
     defects = cT.PrerequisiteInput(
         name='defects',
@@ -1040,8 +993,7 @@ class IsrTaskLSST(pipeBase.PipelineTask):
         if self.config.doCrosstalk:
             # Input units: electrons
             self.log.info("Applying crosstalk correction.")
-            self.crosstalk.run(ccdExposure, crosstalk=crosstalk,
-                               crosstalkSources=crosstalkSources)
+            self.crosstalk.run(ccdExposure, crosstalk=crosstalk)
 
         # Masking block (defects, NAN pixels and trails).
         # Saturated and suspect pixels have already been masked.

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -395,9 +395,10 @@ class IsrTaskLSSTConfig(pipeBase.PipelineTaskConfig,
         "when brighter-fatter correction is applied.",
         default=0,
     )
-    fwhm = pexConfig.Field(
+    fwhmInterBF = pexConfig.Field(
         dtype=float,
-        doc="FWHM of PSF in arcseconds.",
+        doc="FWHM of PSF in arcseconds used for interpolation in brighter-fatter correction "
+        "(currently unused).",
         default=1.0,
     )
     growSaturationFootprintSize = pexConfig.Field(
@@ -788,7 +789,7 @@ class IsrTaskLSST(pipeBase.PipelineTask):
         with self.flatContext(interpExp, flat, dark):
             isrFunctions.interpolateFromMask(
                 maskedImage=interpExp.getMaskedImage(),
-                fwhm=self.config.fwhm,
+                fwhm=self.config.fwhmInterBF,
                 growSaturatedFootprints=self.config.growSaturationFootprintSize,
                 maskNameList=list(self.config.brighterFatterMaskListToInterpolate)
             )
@@ -1022,7 +1023,7 @@ class IsrTaskLSST(pipeBase.PipelineTask):
             self.log.info("Interpolating masked pixels.")
             isrFunctions.interpolateFromMask(
                 maskedImage=ccdExposure.getMaskedImage(),
-                fwhm=self.config.fwhm,
+                fwhm=self.config.fwhmInterBF,
                 growSaturatedFootprints=self.config.growSaturationFootprintSize,
                 maskNameList=list(self.config.maskListToInterpolate)
             )

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -106,7 +106,6 @@ class IsrTaskLSSTConnections(pipeBase.PipelineTaskConnections,
         doc="Linearity correction calibration.",
         dimensions=["instrument", "detector"],
         isCalibration=True,
-        minimum=0,  # can fall back to cameraGeom
     )
     ptc = cT.PrerequisiteInput(
         name="ptc",
@@ -121,7 +120,6 @@ class IsrTaskLSSTConnections(pipeBase.PipelineTaskConnections,
         storageClass="CrosstalkCalib",
         dimensions=["instrument", "detector"],
         isCalibration=True,
-        minimum=0,  # can fall back to cameraGeom
     )
     crosstalkSources = cT.PrerequisiteInput(
         name="isrOverscanCorrected",
@@ -146,7 +144,6 @@ class IsrTaskLSSTConnections(pipeBase.PipelineTaskConnections,
         storageClass="BrighterFatterKernel",
         dimensions=["instrument", "detector"],
         isCalibration=True,
-        minimum=0,
     )
     dark = cT.PrerequisiteInput(
         name='dark',

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -306,7 +306,7 @@ class IsrTaskLSSTConfig(pipeBase.PipelineTaskConfig,
     usePtcGains = pexConfig.Field(
         dtype=bool,
         doc="Use the gain values from the Photon Transfer Curve?",
-        default=True,
+        default=False,
     )
     readNoise = pexConfig.Field(
         dtype=float,

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -151,7 +151,6 @@ class IsrTaskLSSTConnections(pipeBase.PipelineTaskConnections,
         if config.usePtcGains is not True and config.usePtcReadNoise is not True:
             del self.ptc
         if config.doCrosstalk is not True:
-            del self.crosstalkSources
             del self.crosstalk
         if config.doDefect is not True:
             del self.defects
@@ -915,7 +914,7 @@ class IsrTaskLSST(pipeBase.PipelineTask):
 
     def run(self, *, ccdExposure, dnlLUT=None, bias=None, deferredChargeCalib=None, linearizer=None,
             ptc=None, crosstalk=None, defects=None, bfKernel=None, bfGains=None, dark=None,
-            crosstalkSources=None, flat=None, **kwargs
+            flat=None, **kwargs
             ):
 
         detector = ccdExposure.getDetector()

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -146,7 +146,7 @@ class IsrTaskLSSTConnections(pipeBase.PipelineTaskConnections,
         storageClass="BrighterFatterKernel",
         dimensions=["instrument", "detector"],
         isCalibration=True,
-        minimum=0,  # can use either bfKernel or newBFKernel
+        minimum=0,
     )
     dark = cT.PrerequisiteInput(
         name='dark',

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -394,7 +394,7 @@ class IsrTaskLSSTConfig(pipeBase.PipelineTaskConfig,
         "when brighter-fatter correction is applied.",
         default=0,
     )
-    fwhmInterBF = pexConfig.Field(
+    brighterFatterFwhmForInterpolation = pexConfig.Field(
         dtype=float,
         doc="FWHM of PSF in arcseconds used for interpolation in brighter-fatter correction "
         "(currently unused).",
@@ -801,7 +801,7 @@ class IsrTaskLSST(pipeBase.PipelineTask):
         with self.flatContext(interpExp, flat, dark):
             isrFunctions.interpolateFromMask(
                 maskedImage=interpExp.getMaskedImage(),
-                fwhm=self.config.fwhmInterBF,
+                fwhm=self.config.brighterFatterFwhmForInterpolation,
                 growSaturatedFootprints=self.config.growSaturationFootprintSize,
                 maskNameList=list(self.config.brighterFatterMaskListToInterpolate)
             )
@@ -1057,7 +1057,7 @@ class IsrTaskLSST(pipeBase.PipelineTask):
             self.log.info("Interpolating masked pixels.")
             isrFunctions.interpolateFromMask(
                 maskedImage=ccdExposure.getMaskedImage(),
-                fwhm=self.config.fwhmInterBF,
+                fwhm=self.config.brighterFatterFwhmForInterpolation,
                 growSaturatedFootprints=self.config.growSaturationFootprintSize,
                 maskNameList=list(self.config.maskListToInterpolate)
             )

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -93,7 +93,7 @@ class IsrTaskLSSTConnections(pipeBase.PipelineTaskConnections,
     )
     bfKernel = cT.PrerequisiteInput(
         name='brighterFatterKernel',
-        doc="Newer complete kernel + gain solutions.",
+        doc="Complete kernel + gain solutions.",
         storageClass="BrighterFatterKernel",
         dimensions=["instrument", "detector"],
         isCalibration=True,

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -322,11 +322,6 @@ class IsrTaskLSSTConfig(pipeBase.PipelineTaskConfig,
         doc="Widen bleed trails based on their width.",
         default=True,
     )
-    doCameraSpecificMasking = pexConfig.Field(
-        dtype=bool,
-        doc="Mask camera-specific bad regions?",
-        default=False,
-    )
     masking = pexConfig.ConfigurableField(
         target=MaskingTask,
         doc="Masking task."
@@ -1014,10 +1009,6 @@ class IsrTaskLSST(pipeBase.PipelineTask):
         if self.config.doWidenSaturationTrails:
             self.log.info("Widening saturation trails.")
             isrFunctions.widenSaturationTrails(ccdExposure.getMaskedImage().getMask())
-
-        if self.config.doCameraSpecificMasking:
-            self.log.info("Masking regions for camera specific reasons.")
-            self.masking.run(ccdExposure)
 
         preInterpExp = None
         if self.config.doSaveInterpPixels:

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -14,7 +14,6 @@ import lsst.pex.config as pexConfig
 import lsst.afw.math as afwMath
 import lsst.pipe.base as pipeBase
 import lsst.pipe.base.connectionTypes as cT
-from lsst.daf.butler import DimensionGraph
 from lsst.meas.algorithms.detection import SourceDetectionTask
 
 from .overscan import OverscanCorrectionTask
@@ -24,6 +23,7 @@ from .crosstalk import CrosstalkTask
 from .masking import MaskingTask
 from .isrStatistics import IsrStatisticsTask
 from .isr import maskNans
+
 
 class IsrTaskLSSTConnections(pipeBase.PipelineTaskConnections,
                              dimensions={"instrument", "exposure", "detector"},
@@ -524,11 +524,7 @@ class IsrTaskLSST(pipeBase.PipelineTask):
         return gains, readNoise
 
     def updateVariance(self, ampExposure, amp, ptcDataset=None):
-        """Set the variance plane using the gain and read noise
-
-        The read noise is calculated from the ``overscanImage`` if the
-        ``doEmpiricalReadNoise`` option is set in the configuration; otherwise
-        the value from the amplifier data is used.
+        """Set the variance plane using the gain and read noise.
 
         Parameters
         ----------
@@ -549,7 +545,6 @@ class IsrTaskLSST(pipeBase.PipelineTask):
         --------
         lsst.ip.isr.isrFunctions.updateVariance
         """
-        maskPlanes = [self.config.saturatedMaskName, self.config.suspectMaskName]
         if self.config.usePtcGains:
             if ptcDataset is None:
                 raise RuntimeError("No ptcDataset provided to use PTC gains.")
@@ -610,8 +605,7 @@ class IsrTaskLSST(pipeBase.PipelineTask):
                 self.log.debug("Constructing variance map for amplifer %s.", amp.getName())
                 ampExposure = ccdExposure.Factory(ccdExposure, amp.getBBox())
 
-                self.updateVariance(ampExposure, amp,
-                                        ptcDataset=ptc)
+                self.updateVariance(ampExposure, amp, ptcDataset=ptc)
 
                 if self.config.qa is not None and self.config.qa.saveStats is True:
                     qaStats = afwMath.makeStatistics(ampExposure.getVariance(),

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -965,7 +965,7 @@ class IsrTaskLSST(pipeBase.PipelineTask):
         return self.config.doLinearize and \
             detector.getAmplifiers()[0].getLinearityType() != NullLinearityType
 
-    def run(self, ccdExposure, dnlLUT=None, bias=None, deferredChargeCalib=None, linearizer=None,
+    def run(self, *, ccdExposure, dnlLUT=None, bias=None, deferredChargeCalib=None, linearizer=None,
             ptc=None, crosstalk=None, defects=None, bfKernel=None, bfGains=None, dark=None,
             crosstalkSources=None, flat=None, **kwargs
             ):

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -271,7 +271,7 @@ class IsrTaskLSSTConfig(pipeBase.PipelineTaskConfig,
     doDeferredCharge = pexConfig.Field(
         dtype=bool,
         doc="Apply deferred charge correction?",
-        default=False,
+        default=True,
     )
     deferredChargeCorrection = pexConfig.ConfigurableField(
         target=DeferredChargeTask,
@@ -306,7 +306,7 @@ class IsrTaskLSSTConfig(pipeBase.PipelineTaskConfig,
     usePtcGains = pexConfig.Field(
         dtype=bool,
         doc="Use the gain values from the Photon Transfer Curve?",
-        default=False,
+        default=True,
     )
     readNoise = pexConfig.Field(
         dtype=float,
@@ -321,7 +321,7 @@ class IsrTaskLSSTConfig(pipeBase.PipelineTaskConfig,
     usePtcReadNoise = pexConfig.Field(
         dtype=bool,
         doc="Use readnoise values from the Photon Transfer Curve?",
-        default=False,
+        default=True,
     )
     maskNegativeVariance = pexConfig.Field(
         dtype=bool,
@@ -350,7 +350,7 @@ class IsrTaskLSSTConfig(pipeBase.PipelineTaskConfig,
     doCrosstalk = pexConfig.Field(
         dtype=bool,
         doc="Apply intra-CCD crosstalk correction?",
-        default=False,
+        default=True,
     )
     doCrosstalkBeforeAssemble = pexConfig.Field(
         dtype=bool,
@@ -416,7 +416,7 @@ class IsrTaskLSSTConfig(pipeBase.PipelineTaskConfig,
     doBrighterFatter = pexConfig.Field(
         dtype=bool,
         doc="Apply the brighter-fatter correction?",
-        default=False,
+        default=True,
     )
     brighterFatterLevel = pexConfig.ChoiceField(
         dtype=str,
@@ -497,7 +497,7 @@ class IsrTaskLSSTConfig(pipeBase.PipelineTaskConfig,
     doCalculateStatistics = pexConfig.Field(
         dtype=bool,
         doc="Should additional ISR statistics be calculated?",
-        default=False,
+        default=True,
     )
     isrStats = pexConfig.ConfigurableField(
         target=IsrStatisticsTask,

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -210,12 +210,6 @@ class IsrTaskLSSTConfig(pipeBase.PipelineTaskConfig,
 
     Items are grouped in the order in which they are executed by the task.
     """
-    datasetType = pexConfig.Field(
-        dtype=str,
-        doc="Dataset type for input data; users will typically leave this alone, "
-        "but camera-specific ISR tasks will override it.",
-        default="raw",
-    )
     expectWcs = pexConfig.Field(
         dtype=bool,
         default=True,

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -591,8 +591,8 @@ class IsrTaskLSST(pipeBase.PipelineTask):
 
         return overscans
 
-    def snapCombine(self,**kwargs):
-        #TODO DM 36638
+    def snapCombine(self, **kwargs):
+        # TODO DM 36638
         pass
 
     def getLinearizer(self, detector):

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -197,10 +197,6 @@ class IsrTaskLSSTConnections(pipeBase.PipelineTaskConnections,
         if config.doDark is not True:
             self.prerequisiteInputs.remove("dark")
 
-        if config.doWrite is not True:
-            self.outputs.remove("outputExposure")
-            self.outputs.remove("preInterpExposure")
-
         if config.doSaveInterpPixels is not True:
             self.outputs.remove("preInterpExposure")
 
@@ -494,14 +490,6 @@ class IsrTaskLSSTConfig(pipeBase.PipelineTaskConfig,
     doFluence = pexConfig.Field(
         dtype=bool,
         doc="Apply post-ISR operations?",
-        default=True,
-    )
-
-    # Write the outputs to disk. If ISR is run as a subtask, this may not
-    # be needed.
-    doWrite = pexConfig.Field(
-        dtype=bool,
-        doc="Persist postISRCCD?",
         default=True,
     )
 

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -303,7 +303,7 @@ class IsrTaskLSSTConfig(pipeBase.PipelineTaskConfig,
     usePtcGains = pexConfig.Field(
         dtype=bool,
         doc="Use the gain values from the Photon Transfer Curve?",
-        default=False,
+        default=True,
     )
     readNoise = pexConfig.Field(
         dtype=float,

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -141,33 +141,33 @@ class IsrTaskLSSTConnections(pipeBase.PipelineTaskConnections,
         super().__init__(config=config)
 
         if config.doDiffNonLinearCorrection is not True:
-            self.prerequisiteInputs.remove("dnlLUT")
+            del self.dnlLUT
         if config.doBias is not True:
-            self.prerequisiteInputs.remove("bias")
+            del self.bias
         if config.doDeferredCharge is not True:
-            self.prerequisiteInputs.remove("deferredChargeCalib")
+            del self.deferredChargeCalib
         if config.doLinearize is not True:
-            self.prerequisiteInputs.remove("linearizer")
+            del self.linearizer
         if config.usePtcGains is not True and config.usePtcReadNoise is not True:
-            self.prerequisiteInputs.remove("ptc")
+            del self.ptc
         if config.doCrosstalk is not True:
-            self.prerequisiteInputs.remove("crosstalkSources")
-            self.prerequisiteInputs.remove("crosstalk")
+            del self.crosstalkSources
+            del self.crosstalk
         if config.doDefect is not True:
-            self.prerequisiteInputs.remove("defects")
+            del self.defects
         if config.doBrighterFatter is not True:
-            self.prerequisiteInputs.remove("bfKernel")
+            del self.bfKernel
         if config.doDark is not True:
-            self.prerequisiteInputs.remove("dark")
+            del self.dark
 
         if config.doBinnedExposures is not True:
-            self.outputs.remove("outputBin1Exposure")
-            self.outputs.remove("outputBin2Exposure")
+            del self.outputBin1Exposure
+            del self.outputBin2Exposure
         if config.doSaveInterpPixels is not True:
-            self.outputs.remove("preInterpExposure")
+            del self.preInterpExposure
 
         if config.doCalculateStatistics is not True:
-            self.outputs.remove("outputStatistics")
+            del self.outputStatistics
 
 
 class IsrTaskLSSTConfig(pipeBase.PipelineTaskConfig,

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -352,11 +352,6 @@ class IsrTaskLSSTConfig(pipeBase.PipelineTaskConfig,
         doc="Apply intra-CCD crosstalk correction?",
         default=True,
     )
-    doCrosstalkBeforeAssemble = pexConfig.Field(
-        dtype=bool,
-        doc="Apply crosstalk correction before CCD assembly?",
-        default=False,
-    )
     crosstalk = pexConfig.ConfigurableField(
         target=CrosstalkTask,
         doc="Intra-CCD crosstalk correction.",

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -1,0 +1,167 @@
+class IsrTaskLSSTConnections(pipeBase.PipelineTaskConnections,
+                         dimensions={"instrument", "exposure", "detector"},
+                         defaultTemplates={}):
+    ccdExposure = cT.Input(
+        name="raw",
+        doc="Input exposure to process.",
+        storageClass="Exposure",
+        dimensions=["instrument", "exposure", "detector"],
+    )
+    camera = cT.PrerequisiteInput(
+        name="camera",
+        storageClass="Camera",
+        doc="Input camera to construct complete exposures.",
+        dimensions=["instrument"],
+        isCalibration=True,
+    )
+    #Non-linearity correction DM-36636
+
+class isrTaskLSST(pipeBase.PipelineTask):
+    ConfigClass = IsrTaskLSSTConfig
+    _DefaultName = "isr"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.makeSubtask("assembleCcd")
+        self.makeSubtask("crosstalk")
+        self.makeSubtask("strayLight")
+        self.makeSubtask("fringe")
+        self.makeSubtask("masking")
+        self.makeSubtask("overscan")
+        self.makeSubtask("vignette")
+        self.makeSubtask("ampOffset")
+        self.makeSubtask("deferredChargeCorrection")
+        self.makeSubtask("isrStats")
+
+    def runQuantum(self, butlerQC, inputRefs, outputRefs):
+        super().runQuantum(self, butlerQC, inputRefs, outputRefs)
+
+    def validateInput(self,**kwargs):
+        """
+        This is a check that all the inputs required by the config
+        are available.
+        """
+
+        inputMap = {'bias': self.config.doBias}
+        for calibrationFile,configValue in inputMap.items():
+            #TODO do checks for fringes, illumination correction, etc
+            if inputMap[calibrationFile] is None and configValue:
+                raise RuntimeError("Must supply ",calibrationFile)
+
+
+    def diffNonLinearCorrection(self,ccdExposure,dnlLUT,**kwargs):
+        #TODO DM 36636
+        #isrFunctions.diffNonLinearCorrection
+        pass
+
+    def overscanCorrection(self, ccd, ccdExposure):
+        #TODO DM 36637 for per amp
+
+        overscans = []
+        for amp in ccd:
+
+            # Overscan correction on amp-by-amp basis.
+            if amp.getRawHorizontalOverscanBBox().isEmpty():
+                self.log.info("ISR_OSCAN: No overscan region.  Not performing overscan correction.")
+                overscans.append(None)
+            else:
+
+                # Perform overscan correction on subregions.
+                overscanResults = self.overscan.run(ccdExposure, amp)
+
+                self.log.debug("Corrected overscan for amplifier %s.", amp.getName())
+                if len(overscans) == 0:
+                    ccdExposure.getMetadata().set('OVERSCAN', "Overscan corrected")
+
+                overscans.append(overscanResults if overscanResults is not None else None)
+
+        return overscans
+
+    def snapCombine(self,**kwargs):
+        #TODO DM 36638
+        pass
+
+    def gainNormalize(self,**kwargs):
+        #TODO DM 36639
+        gains = []
+        readNoise = []
+
+        return gains, readNoise
+
+    def variancePlane(self, ccdExposure, ccd, overscans, gains, readNoises, **kwargs):
+        for amp, gain, readNoise in zip(ccd, gains,readNoises):
+            if ccdExposure.getBBox().contains(amp.getBBox()):
+                self.log.debug("Constructing variance map for amplifer %s.", amp.getName())
+                ampExposure = ccdExposure.Factory(ccdExposure, amp.getBBox())
+
+                isrFunctions.updateVariance(
+                        maskedImage=ampExposure.getMaskedImage(),
+                        gain=gain,
+                        readNoise=readNoise,
+                        )
+
+#                if self.config.maskNegativeVariance:
+#                    self.maskNegativeVariance(ccdExposure)
+
+    def run(self,**kwargs):
+
+        ccd = ccdExposure.getDetector()
+        filterLabel = ccdExposure.getFilter()
+        physicalFilter = isrFunctions.getPhysicalFilter(filterLabel, self.log)
+
+        self.validateInput(**kwargs)
+        if self.config.doDiffNonLinearCorrection:
+            self.diffNonLinearCorrection(ccdExposure,dnlLUT,**kwargs)
+        if self.config.doOverscan:
+            overscans = self.overscanCorrection(self, ccd, ccdExposure)
+
+        if self.config.doAssembleCcd:
+            self.log.info("Assembling CCD from amplifiers.")
+            ccdExposure = self.assembleCcd.assembleCcd(ccdExposure)
+
+            if self.config.expectWcs and not ccdExposure.getWcs():
+                self.log.warning("No WCS found in input exposure.")
+            self.debugView(ccdExposure, "doAssembleCcd")
+
+        if self.config.doSnapCombine:
+            self.snapCombine(**kwargs)
+
+        if self.config.doBias:
+            self.log.info("Applying bias correction.")
+            isrFunctions.biasCorrection(ccdExposure.getMaskedImage(), bias.getMaskedImage(),
+                                        trimToFit=self.config.doTrimToMatchCalib)
+            self.debugView(ccdExposure, "doBias")
+
+        if self.config.doDeferredCharge:
+            self.log.info("Applying deferred charge/CTI correction.")
+            self.deferredChargeCorrection.run(ccdExposure, deferredChargeCalib)
+            self.debugView(ccdExposure, "doDeferredCharge")
+
+
+        if self.config.doLinearize:
+            self.log.info("Applying linearizer.")
+            linearizer.applyLinearity(image=ccdExposure.getMaskedImage().getImage(),
+                                      detector=ccd, log=self.log)
+
+        if self.config.doGainNormalize:
+            gains, readNoise = self.gainNormalize(**kwargs)
+
+        if self.config.doVariance:
+            self.variancePlane(gains, readNoise, **kwargs)
+
+        if self.config.doCrosstalk:
+            self.log.info("Applying crosstalk correction.")
+            self.crosstalk.run(ccdExposure, crosstalk=crosstalk,
+                               crosstalkSources=crosstalkSources, isTrimmed=True)
+            self.debugView(ccdExposure, "doCrosstalk")
+
+
+
+
+
+
+
+
+
+
+

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -408,13 +408,6 @@ class IsrTaskLSSTConfig(pipeBase.PipelineTaskConfig,
         default=True,
     )
 
-    # Post-ISR operations to make fluence image.
-    doFluence = pexConfig.Field(
-        dtype=bool,
-        doc="Apply post-ISR operations?",
-        default=True,
-    )
-
     # Calculate image quality statistics?
     doStandardStatistics = pexConfig.Field(
         dtype=bool,
@@ -870,10 +863,6 @@ class IsrTaskLSST(pipeBase.PipelineTask):
             invert=invert,
         )
 
-    def applyPostIsr(self, **kwargs):
-        # TODO add post-ISR (4th column of Eli's calibration boxes)
-        pass
-
     @staticmethod
     def extractCalibDate(calib):
         """Extract common calibration metadata values that will be written to
@@ -1041,11 +1030,6 @@ class IsrTaskLSST(pipeBase.PipelineTask):
             # Input units: electrons
             self.log.info("Applying dark subtraction.")
             self.darkCorrection(ccdExposure, dark)
-
-        if self.config.doFluence:
-            # Inputs units: electrons
-            self.log.info("Applying post-ISR operations.")
-            self.applyPostIsr(**kwargs)
 
         # Calculate standard image quality statistics
         if self.config.doStandardStatistics:


### PR DESCRIPTION
Here is a first draft of the new isr task implementing calibpalooza ISR steps order.
The new task is called isrTaskLSST.
Note that there are a lot of things missing: upstream changes to the ISR task, few docstring, unit test, further testing. These will be in follow-up tickets.
Note also that we are focusing on LSSTCam and not trying to have HSC and DECam use this task. Can be done if needed in follow-up tickets.  
Also, I ran into git issues multiple times so I ended up re-commiting the isrTaskLSST file in big chunks in only a few commits. 