### PR TITLE
DM-42708: Avoid printing debug logs directly to stdout

### DIFF
--- a/python/lsst/ip/isr/fringe.py
+++ b/python/lsst/ip/isr/fringe.py
@@ -115,7 +115,8 @@ class FringeTask(Task):
         if expId is None:
             seed = self.config.stats.rngSeedOffset
         else:
-            print(f"{self.config.stats.rngSeedOffset} {expId}")
+            self.log.debug("Seeding with offset %d and ccdExposureId %d.",
+                           self.config.stats.rngSeedOffset, expId)
             seed = self.config.stats.rngSeedOffset + expId
 
         # Seed for numpy.random.RandomState must be convertable to a 32 bit


### PR DESCRIPTION
This PR fixes a log that was printed using `print` instead of `debug` (added on #116). It is the only non-UI `print` statement in the package code.