### PR TITLE
DM-42795: Fix incorrect NOISE_LIST access.

### DIFF
--- a/python/lsst/ip/isr/ptcDataset.py
+++ b/python/lsst/ip/isr/ptcDataset.py
@@ -627,7 +627,6 @@ class PhotonTransferCurveDataset(IsrCalib):
             inDict['rawVars'][ampName] = record['RAW_VARS']
             inDict['gain'][ampName] = record['GAIN']
             inDict['gainErr'][ampName] = record['GAIN_ERR']
-            inDict['noiseList'][ampName] = record['NOISE_LIST']
             inDict['noise'][ampName] = record['NOISE']
             inDict['noiseErr'][ampName] = record['NOISE_ERR']
             inDict['ptcFitPars'][ampName] = record['PTC_FIT_PARS']


### PR DESCRIPTION
Remove incorrect NOISE_LIST access.

As this is a newly added field, it should only be set in a version controlled block.  This ticket removes the extra assignment.