### PR TITLE
DM-42732: Add missing bias shift data

### DIFF
--- a/python/lsst/ip/isr/isrStatistics.py
+++ b/python/lsst/ip/isr/isrStatistics.py
@@ -805,6 +805,7 @@ class IsrStatisticsTask(pipeBase.Task):
                     imC = np.corrcoef(ampImage, ampImage2)[0, 1]
                 rows.append(
                     {'detector': detector.getId(),
+                     'detectorComp': detector.getId(),
                      'ampName': detector[ampId].getName(),
                      'ampComp': detector[ampId2].getName(),
                      'imageCorr': float(imC),


### PR DESCRIPTION
This also adds the update amp correlation results.