### PR TITLE
DM-42999: Demote routine "warnings" and fix build problems

### DIFF
--- a/doc/lsst.ip.isr/index.rst
+++ b/doc/lsst.ip.isr/index.rst
@@ -17,6 +17,20 @@ Contributing
 ``lsst.ip.isr`` is developed at https://github.com/lsst/ip_isr.
 You can find Jira issues for this module under the `ip_isr <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20ip_isr>`_ component.
 
+.. _lsst.ip.isr-command-line-taskref:
+
+Task reference
+==============
+
+.. _lsst.ip.isr-tasks:
+
+Tasks
+-----
+
+.. lsst-tasks::
+   :root: lsst.ip.isr
+   :toctree: tasks
+
 Python API reference
 ====================
 

--- a/doc/lsst.ip.isr/tasks/lsst.ip.isr.assembleCcdTask.AssembleCcdTask.rst
+++ b/doc/lsst.ip.isr/tasks/lsst.ip.isr.assembleCcdTask.AssembleCcdTask.rst
@@ -1,0 +1,65 @@
+.. lsst-task-topic:: lsst.ip.isr.AssembleCcdTask
+
+###############
+AssembleCcdTask
+###############
+
+``AssembleCcdTask`` assembles sections of an image into a larger mosaic.
+The sub-sections are typically amplifier sections and are to be assembled into a detector size pixel grid.
+The assembly is driven by the entries in the raw amp information.
+The task can be configured to return a detector image with non-data (e.g. overscan) pixels included.
+The task can also renormalize the pixel values to a nominal gain of 1.
+The task also removes exposure metadata that has context in raw amps, but not in trimmed detectors (e.g. 'BIASSEC').
+
+.. _lsst.ip.isr.AssembleCcdTask-summary:
+
+Processing summary
+==================
+
+.. If the task does not break work down into multiple steps, don't use a list.
+.. Instead, summarize the computation itself in a paragraph or two.
+
+``AssembleCcdTask`` does not have a ``run`` method.
+Instead, its main methods are `~lsst.ip.isr.AssembleCcdTask.assembleCcd` and `~lsst.ip.isr.AssembleCcdTask.postprocessExposure`.
+
+.. ``ExampleTask`` runs this sequence of operations:
+
+.. #. Runs this thing. (FIXME)
+
+.. #. Processes processes that intermediate result. (FIXME)
+
+.. #. Stores those results in this last step. (FIXME)
+
+.. _lsst.ip.isr.AssembleCcdTask-api:
+
+Python API summary
+==================
+
+.. lsst-task-api-summary:: lsst.ip.isr.AssembleCcdTask
+
+.. _lsst.ip.isr.AssembleCcdTask-subtasks:
+
+Retargetable subtasks
+=====================
+
+.. lsst-task-config-subtasks:: lsst.ip.isr.AssembleCcdTask
+
+.. _lsst.ip.isr.AssembleCcdTask-configs:
+
+Configuration fields
+====================
+
+.. lsst-task-config-fields:: lsst.ip.isr.AssembleCcdTask
+
+.. _lsst.ip.isr.AssembleCcdTask-debug:
+
+Debugging
+=========
+
+The available debug variables in AssembleCcdTask are:
+
+``display``
+    A dictionary containing debug point names as keys with frame number as value. Valid keys are:
+
+    assembledExposure
+        display assembled exposure

--- a/python/lsst/ip/isr/ampOffset.py
+++ b/python/lsst/ip/isr/ampOffset.py
@@ -267,20 +267,23 @@ class AmpOffsetTask(Task):
             and column index corresponds to the ampIds of a specific pair of
             amplifiers, and the matrix elements indicate their associations as
             follows:
-            0: No association
-            -1: Association exists (direction specified in the ampSides matrix)
-            n >= 1: Diagonal elements indicate the number of neighboring
-                    amplifiers for the corresponding ampId==row==column number.
+
+            * 0: No association
+            * -1: Association exists (direction specified in the ampSides
+              matrix)
+            * n >= 1: Diagonal elements indicate the number of neighboring
+              amplifiers for the corresponding ampId==row==column number.
 
         ampSides : `numpy.ndarray`
             An N x N matrix (N = the number of amplifiers) representing the amp
             side information corresponding to the `ampAssociations`
             matrix. The elements are integers defined as below:
-            -1: No side due to no association or the same amp (diagonals)
-            0: Side on the bottom
-            1: Side on the right
-            2: Side on the top
-            3: Side on the left
+
+            * -1: No side due to no association or the same amp (diagonals)
+            * 0: Side on the bottom
+            * 1: Side on the right
+            * 2: Side on the top
+            * 3: Side on the left
         """
         xCenters = [amp.getBBox().getCenterX() for amp in amps]
         yCenters = [amp.getBBox().getCenterY() for amp in amps]

--- a/python/lsst/ip/isr/assembleCcdTask.py
+++ b/python/lsst/ip/isr/assembleCcdTask.py
@@ -57,79 +57,9 @@ class AssembleCcdTask(pipeBase.Task):
     @brief Assemble a set of amplifier images into a full detector size set of
     pixels.
 
-    @section ip_isr_assemble_Contents Contents
-
-     - @ref ip_isr_assemble_Purpose
-     - @ref ip_isr_assemble_Initialize
-     - @ref ip_isr_assemble_IO
-     - @ref ip_isr_assemble_Config
-     - @ref ip_isr_assemble_Debug
-     - @ref ip_isr_assemble_Example
-
-    @section ip_isr_assemble_Purpose Description
-
-    This task assembles sections of an image into a larger mosaic.  The
-    sub-sections are typically amplifier sections and are to be assembled
-    into a detector size pixel grid. The assembly is driven by the entries in
-    the raw amp information.  The task can be configured to return a detector
-    image with non-data (e.g. overscan) pixels included.  The task can also
-    renormalize the pixel values to a nominal gain of 1.  The task also
-    removes exposure metadata that has context in raw amps, but not in trimmed
-    detectors (e.g. 'BIASSEC').
-
     @section ip_isr_assemble_Initialize Task initialization
 
     @copydoc __init__
-
-    @section ip_isr_assemble_IO Inputs/Outputs to the assembleCcd method
-
-    @copydoc assembleCcd
-
-    @section ip_isr_assemble_Config Configuration parameters
-
-    See @ref AssembleCcdConfig
-
-    @section ip_isr_assemble_Debug Debug variables
-
-    The command line task interface supports a flag @c -d to import @b debug.py from your
-    @c PYTHONPATH; see <a
-    href="https://developer.lsst.io/stack/debug.html">Debugging Tasks with
-    lsstDebug</a> for more about @b debug.py files.
-
-    The available variables in AssembleCcdTask are:
-    <DL>
-      <DT> @c display
-      <DD> A dictionary containing debug point names as keys with frame number
-           as value. Valid keys are:
-        <DL>
-          <DT> assembledExposure
-          <DD> display assembled exposure
-        </DL>
-    </DL>
-
-    @section ip_isr_assemble_Example A complete example of using
-    AssembleCcdTask
-
-    <HR>
-    To investigate the @ref ip_isr_assemble_Debug, put something like
-    @code{.py}
-    import lsstDebug
-    def DebugInfo(name):
-        di = lsstDebug.getInfo(name)  # N.b. lsstDebug.Info(name) would call
-                                      # us recursively
-        if name == "lsst.ip.isr.assembleCcdTask":
-            di.display = {'assembledExposure':2}
-        return di
-
-    lsstDebug.Info = DebugInfo
-    @endcode
-    into your debug.py file and run runAssembleTask.py with the @c --debug
-    flag.
-
-
-    Conversion notes:
-        Display code should be updated once we settle on a standard way of
-        controlling what is displayed.
     """
     ConfigClass = AssembleCcdConfig
     _DefaultName = "assembleCcd"

--- a/python/lsst/ip/isr/isrStatistics.py
+++ b/python/lsst/ip/isr/isrStatistics.py
@@ -338,7 +338,7 @@ class IsrStatisticsTask(pipeBase.Task):
 
         Returns
         -------
-        outputStats : `dict` [`str`, [`dict` [`str`,`float]]
+        outputStats : `dict` [`str`, [`dict` [`str`, `float`]]]
             Dictionary of measurements, keyed by amplifier name and
             statistics segment.
         """
@@ -462,7 +462,7 @@ class IsrStatisticsTask(pipeBase.Task):
 
         Returns
         -------
-        outputStats : `dict` [`str`, [`dict` [`str`,`float]]
+        outputStats : `dict` [`str`, [`dict` [`str`, `float`]]]
             Dictionary of measurements, keyed by amplifier name and
             statistics segment.
         """
@@ -515,7 +515,7 @@ class IsrStatisticsTask(pipeBase.Task):
 
         Returns
         -------
-        outputStats : `dict` [`str`, [`dict` [`str`,`float]]
+        outputStats : `dict` [`str`, [`dict` [`str`, `float`]]]
             Dictionary of measurements, keyed by amplifier name and
             statistics segment.
         """
@@ -585,7 +585,7 @@ class IsrStatisticsTask(pipeBase.Task):
 
         Returns
         -------
-        outputStats : `dict` [`str`, [`dict` [`str`,`float]]
+        outputStats : `dict` [`str`, [`dict` [`str`, `float`]]]
             Dictionary of measurements, keyed by amplifier name and
             statistics segment.
         """
@@ -643,7 +643,7 @@ class IsrStatisticsTask(pipeBase.Task):
 
         Returns
         -------
-        outputStats : `dict` [`str`, [`dict` [`str`,`float]]
+        outputStats : `dict` [`str`, [`dict` [`str`, `float`]]]
             Dictionary of measurements, keyed by amplifier name and
             statistics segment.
 
@@ -771,7 +771,7 @@ class IsrStatisticsTask(pipeBase.Task):
 
         Returns
         -------
-        outputStats : `dict` [`str`, [`dict` [`str`,`float`]]
+        outputStats : `dict` [`str`, [`dict` [`str`, `float`]]]
             Dictionary of measurements, keyed by amplifier name and
             statistics segment.
 
@@ -826,20 +826,21 @@ class IsrStatisticsTask(pipeBase.Task):
 
         Returns
         -------
-        outputStats : `dict` [`str`, [`dict` [`str`,`float]]
+        outputStats : `dict` [`str`, [`dict` [`str`, `float`]]]
             Dictionary of measurements, keyed by amplifier name and
             statistics segment.
             Measurements include
+
             - DIVISADERO_PROFILE: Robust mean of rows between
-                divisaderoProjection<Maximum|Minumum> on readout edge of ccd
-                normalized by a linear fit to the same rows.
+              divisaderoProjection<Maximum|Minumum> on readout edge of ccd
+              normalized by a linear fit to the same rows.
             - DIVISADERO_MAX_PAIR: Tuple of maximum of the absolute values of
-                the DIVISADERO_PROFILE, for number of pixels (specified by
-                divisaderoNumImpactPixels on left and right side of amp.
+              the DIVISADERO_PROFILE, for number of pixels (specified by
+              divisaderoNumImpactPixels on left and right side of amp.
             - DIVISADERO_MAX: Maximum of the absolute values of the
-                the DIVISADERO_PROFILE, for the divisaderoNumImpactPixels on
-                boundaries of neighboring amps (including the pixels in those
-                neighborboring amps).
+              the DIVISADERO_PROFILE, for the divisaderoNumImpactPixels on
+              boundaries of neighboring amps (including the pixels in those
+              neighborboring amps).
         """
         outputStats = {}
 

--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -1784,7 +1784,7 @@ class IsrTask(pipeBase.PipelineTask):
         with nominal gains and noise.
 
         Parameters
-        ------
+        ----------
         ptcDataset : `lsst.ip.isr.PhotonTransferCurveDataset`
             Input Photon Transfer Curve dataset.
         detector : `lsst.afw.cameraGeom.Detector`

--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -1062,11 +1062,12 @@ class IsrTask(pipeBase.PipelineTask):
                     self.log.warning("Bare lookup table linearizers will be deprecated in DM-28741.")
                 else:
                     linearizer = inputs['linearizer']
+                    self.log.info("Loading linearizer from the Butler.")
                     linearizer.log = self.log
                 inputs['linearizer'] = linearizer
             else:
                 inputs['linearizer'] = linearize.Linearizer(detector=detector, log=self.log)
-                self.log.warning("Constructing linearizer from cameraGeom information.")
+                self.log.info("Constructing linearizer from cameraGeom information.")
 
         if self.config.doDefect is True:
             if "defects" in inputs and inputs['defects'] is not None:

--- a/python/lsst/ip/isr/ptcDataset.py
+++ b/python/lsst/ip/isr/ptcDataset.py
@@ -59,7 +59,7 @@ class PhotonTransferCurveDataset(IsrCalib):
     covMatrixSide : `int`, optional
         Maximum lag of measured covariances (size of square covariance
         matrices).
-    covMatrixSideFullCovFit : `int, optional
+    covMatrixSideFullCovFit : `int`, optional
         Maximum covariances lag for FULLCOVARIANCE fit. It should be less or
         equal than covMatrixSide.
     kwargs : `dict`, optional


### PR DESCRIPTION
This PR demotes a `warning` log issued when constructing a linearizer (something the task is specifically configured to do) to `info`. It also fixes numerous documentation errors in both Doxygen and Sphinx, in part by migrating `AssembleCcdTask` to the task topic format.