### PR TITLE
DM-42927: Update cp_verify connections/classes/outputs for analysis_tools

### DIFF
--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -1755,7 +1755,8 @@ class IsrTask(pipeBase.PipelineTask):
         outputStatistics = None
         if self.config.doCalculateStatistics:
             outputStatistics = self.isrStats.run(ccdExposure, overscanResults=overscans,
-                                                 bias=bias, dark=dark, flat=flat, ptc=ptc).results
+                                                 bias=bias, dark=dark, flat=flat, ptc=ptc,
+                                                 defects=defects).results
 
         # do any binning.
         outputBin1Exposure = None

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -1419,7 +1419,8 @@ class IsrTaskLSST(pipeBase.PipelineTask):
         outputStatistics = None
         if self.config.doCalculateStatistics:
             outputStatistics = self.isrStats.run(ccdExposure, overscanResults=serialOverscans,
-                                                 ptc=ptc).results
+                                                 bias=bias, dark=dark, flat=flat, ptc=ptc,
+                                                 defects=defects).results
 
         # do image binning.
         outputBin1Exposure = None


### PR DESCRIPTION
Ensure defects are passes to the IsrStatisticsTask so header keywords can be saved.