### PR TITLE
DM-41442: Add focal plane mosaic construction to cp_pipe/cp_verify

### DIFF
--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -2721,6 +2721,12 @@ class IsrTask(pipeBase.PipelineTask):
         bin1 = afwMath.binImage(mi, self.config.binFactor1)
         bin2 = afwMath.binImage(mi, self.config.binFactor2)
 
+        bin1 = afwImage.makeExposure(bin1)
+        bin2 = afwImage.makeExposure(bin2)
+
+        bin1.setInfo(exposure.getInfo())
+        bin2.setInfo(exposure.getInfo())
+
         return bin1, bin2
 
     def debugView(self, exposure, stepname):


### PR DESCRIPTION
Binned images should be exposures.