### PR TITLE
DM-46052: Updates to IsrTaskLSST based on testing on real LATISS and LSSTCam images.

### DIFF
--- a/python/lsst/ip/isr/crosstalk.py
+++ b/python/lsst/ip/isr/crosstalk.py
@@ -112,8 +112,8 @@ class CrosstalkCalib(IsrCalib):
         self.coeffErr = np.zeros(self.crosstalkShape) if self.nAmp else None
         self.coeffNum = np.zeros(self.crosstalkShape,
                                  dtype=int) if self.nAmp else None
-        self.coeffValid = np.zeros(self.crosstalkShape,
-                                   dtype=bool) if self.nAmp else None
+        self.coeffValid = np.ones(self.crosstalkShape,
+                                  dtype=bool) if self.nAmp else None
         # Quadratic terms, if any.
         self.coeffsSqr = np.zeros(self.crosstalkShape) if self.nAmp else None
         self.coeffErrSqr = np.zeros(self.crosstalkShape) if self.nAmp else None

--- a/python/lsst/ip/isr/crosstalk.py
+++ b/python/lsst/ip/isr/crosstalk.py
@@ -965,12 +965,19 @@ class CrosstalkTask(Task):
         invertGains = False
         gainApply = False
         if crosstalk.crosstalkRatiosUnits != exposureUnits:
-            if gains is None:
+            if gains is None and np.all(crosstalk.fitGains == 0.0):
                 raise RuntimeError(
                     f"Unit mismatch between exposure ({exposureUnits}) and "
                     f"crosstalk ratios ({crosstalk.crosstalkRatiosUnits}) and "
-                    "no gains were supplied.",
+                    "no gains were supplied or available in crosstalk calibration.",
                 )
+            elif gains is None:
+                self.log.info("Using crosstalk calib fitGains for gain corrections.")
+                detector = exposure.getDetector()
+                gains = {}
+                for i, amp in enumerate(detector):
+                    gains[amp.getName()] = crosstalk.fitGains[i]
+
             gainApply = True
 
             if crosstalk.crosstalkRatiosUnits == "adu":

--- a/python/lsst/ip/isr/isrFunctions.py
+++ b/python/lsst/ip/isr/isrFunctions.py
@@ -604,7 +604,7 @@ def brighterFatterCorrection(exposure, kernel, maxIter, threshold, applyGain, ga
                 tmpArray[startY:endY, startX:endX] += corr[startY:endY, startX:endX]
 
             if iteration > 0:
-                diff = numpy.sum(numpy.abs(prev_image - tmpArray))
+                diff = numpy.sum(numpy.abs(prev_image - tmpArray), dtype=numpy.float64)
 
                 if diff < threshold:
                     break

--- a/python/lsst/ip/isr/isrMockLSST.py
+++ b/python/lsst/ip/isr/isrMockLSST.py
@@ -82,12 +82,12 @@ class IsrMockLSSTConfig(IsrMockConfig):
     )
     doAddBadParallelOverscanColumnNeighbors = pexConfig.Field(
         dtype=bool,
-        default=False,
+        default=True,
         doc="Add low-level bad columns next to parallel overscan bad column.",
     )
     badParallelOverscanColumnNeighborsLevel = pexConfig.Field(
         dtype=float,
-        default=100.0,
+        default=50.0,
         doc="Bright parallel overscan column neighbors level (electron).",
     )
     doAddBrighterFatter = pexConfig.Field(

--- a/python/lsst/ip/isr/isrMockLSST.py
+++ b/python/lsst/ip/isr/isrMockLSST.py
@@ -570,11 +570,12 @@ class IsrMockLSST(IsrMock):
 
         # 7b. Add bad column to the parallel overscan region.
         if self.config.doAddBadParallelOverscanColumn and not self.config.isTrimmed:
-            # Only add this to one amp.
-            amp = exposure.getDetector()[1]
+            # We want to place this right above the defect, to simulate
+            # bleeding into the parallel overscan region.
+            amp = exposure.getDetector()[2]
             parBBox = amp.getRawParallelOverscanBBox()
             bboxBad = geom.Box2I(
-                corner=geom.Point2I(parBBox.getMinX() + 30, parBBox.getMinY()),
+                corner=geom.Point2I(50, parBBox.getMinY()),
                 dimensions=geom.Extent2I(1, parBBox.getHeight()),
             )
             exposure[bboxBad].image.array[:, :] = self.config.badParallelOverscanColumnLevel

--- a/python/lsst/ip/isr/isrMockLSST.py
+++ b/python/lsst/ip/isr/isrMockLSST.py
@@ -80,6 +80,16 @@ class IsrMockLSSTConfig(IsrMockConfig):
         default=300000.,
         doc="Bright parallel overscan column level (electron). Should be above saturation.",
     )
+    doAddBadParallelOverscanColumnNeighbors = pexConfig.Field(
+        dtype=bool,
+        default=False,
+        doc="Add low-level bad columns next to parallel overscan bad column.",
+    )
+    badParallelOverscanColumnNeighborsLevel = pexConfig.Field(
+        dtype=float,
+        default=100.0,
+        doc="Bright parallel overscan column neighbors level (electron).",
+    )
     doAddBrighterFatter = pexConfig.Field(
         dtype=bool,
         default=False,
@@ -579,6 +589,14 @@ class IsrMockLSST(IsrMock):
                 dimensions=geom.Extent2I(1, parBBox.getHeight()),
             )
             exposure[bboxBad].image.array[:, :] = self.config.badParallelOverscanColumnLevel
+
+            if self.config.doAddBadParallelOverscanColumnNeighbors:
+                for neighbor in [49, 51]:
+                    bboxBad = geom.Box2I(
+                        corner=geom.Point2I(neighbor, parBBox.getMinY()),
+                        dimensions=geom.Extent2I(1, parBBox.getHeight()),
+                    )
+                    exposure[bboxBad].image.array[:, :] += self.config.badParallelOverscanColumnNeighborsLevel
 
         # 11. Add crosstalk (electron) to all the amplifiers
         #     (imaging + overscan).

--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -1362,18 +1362,21 @@ class IsrTask(pipeBase.PipelineTask):
         exposureMetadata = ccdExposure.getMetadata()
         if self.config.doBias:
             self.compareCameraKeywords(exposureMetadata, bias, "bias")
+            self.compareUnits(bias.metadata, "bias")
         if self.config.doBrighterFatter:
             self.compareCameraKeywords(exposureMetadata, bfKernel, "brighter-fatter")
         if self.config.doCrosstalk:
             self.compareCameraKeywords(exposureMetadata, crosstalk, "crosstalk")
         if self.config.doDark:
             self.compareCameraKeywords(exposureMetadata, dark, "dark")
+            self.compareUnits(dark.metadata, "dark")
         if self.config.doDefect:
             self.compareCameraKeywords(exposureMetadata, defects, "defects")
         if self.config.doDeferredCharge:
             self.compareCameraKeywords(exposureMetadata, deferredChargeCalib, "CTI")
         if self.config.doFlat:
             self.compareCameraKeywords(exposureMetadata, flat, "flat")
+            self.compareUnits(flat.metadata, "flat")
         if (self.config.doFringe and physicalFilter in self.fringe.config.filters):
             self.compareCameraKeywords(exposureMetadata, fringes.fringes, "fringe")
         if (self.config.doIlluminationCorrection and physicalFilter in self.config.illumFilters):
@@ -2035,6 +2038,37 @@ class IsrTask(pipeBase.PipelineTask):
                                          exposureMetadata[keyword], calibMetadata[keyword])
             else:
                 self.log.debug("Sequencer keyword %s not found.", keyword)
+
+    def compareUnits(self, calibMetadata, calibName):
+        """Compare units from calibration to ISR units.
+
+        For the regular IsrTask this is used to confirm that calibs
+        suitable for IsrTaskLSST are not used with the old IsrTask.
+
+        Parameters
+        ----------
+        calibMetadata : `lsst.daf.base.PropertyList`
+            Calibration metadata from header.
+        calibName : `str`
+            Calibration name for log message.
+        """
+        calibUnits = calibMetadata.get("LSST ISR UNITS", "adu")
+        isrUnits = "adu"
+        if calibUnits != isrUnits:
+            if self.config.doRaiseOnCalibMismatch:
+                raise RuntimeError(
+                    "Unit mismatch: isr has %s units but %s has %s units",
+                    isrUnits,
+                    calibName,
+                    calibUnits,
+                )
+            else:
+                self.log.warning(
+                    "Unit mismatch: isr has %s units but %s has %s units",
+                    isrUnits,
+                    calibName,
+                    calibUnits,
+                )
 
     def convertIntToFloat(self, exposure):
         """Convert exposure image from uint16 to float.

--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -2645,10 +2645,18 @@ class IsrTask(pipeBase.PipelineTask):
                     skyLevels[i, j] = afwMath.makeStatistics(miMesh, stat, statsControl).getValue()
 
             good = numpy.where(numpy.isfinite(skyLevels))
-            skyMedian = numpy.median(skyLevels[good])
-            flatness = (skyLevels[good] - skyMedian) / skyMedian
-            flatness_rms = numpy.std(flatness)
-            flatness_pp = flatness.max() - flatness.min() if len(flatness) > 0 else numpy.nan
+            if len(good[0]) == 0:
+                # There are no good pixels.
+                self.log.warning("No good pixels to measure sky levels.")
+                skyMedian = numpy.nan
+                flatness = numpy.nan
+                flatness_rms = numpy.nan
+                flatness_pp = numpy.nan
+            else:
+                skyMedian = numpy.median(skyLevels[good])
+                flatness = (skyLevels[good] - skyMedian) / skyMedian
+                flatness_rms = numpy.std(flatness)
+                flatness_pp = flatness.max() - flatness.min() if len(flatness) > 0 else numpy.nan
 
             self.log.info("Measuring sky levels in %dx%d grids: %f.", nX, nY, skyMedian)
             self.log.info("Sky flatness in %dx%d grids - pp: %f rms: %f.",

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -832,6 +832,25 @@ class IsrTaskLSST(pipeBase.PipelineTask):
                         parallelOverscan = ParallelOverscanCorrectionTask(
                             config=ampConfig.parallelOverscanConfig,
                         )
+
+                        # We need to know the saturation level that was used
+                        # for the parallel overscan masking. If it isn't set
+                        # then the configured parallelOverscanSaturationLevel
+                        # will be used instead (assuming
+                        # doParallelOverscanSaturation is True).
+                        if self.config.doSaturation:
+                            saturationLevel = ccdExposure.metadata[
+                                f"LSST ISR SATURATION LEVEL {amp.getName()}"
+                            ]
+                        else:
+                            saturationLevel = None
+
+                        parallelOverscan.maskParallelOverscanAmp(
+                            ccdExposure,
+                            amp,
+                            saturationLevel=saturationLevel,
+                        )
+
                         results = parallelOverscan.run(ccdExposure, amp)
 
                     metadata = ccdExposure.metadata

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -541,6 +541,7 @@ class IsrTaskLSST(pipeBase.PipelineTask):
         self.makeSubtask("crosstalk")
         self.makeSubtask("masking")
         self.makeSubtask("isrStats")
+        self.makeSubtask("ampOffset")
 
     def runQuantum(self, butlerQC, inputRefs, outputRefs):
 

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -1654,11 +1654,15 @@ class IsrTaskLSST(pipeBase.PipelineTask):
         # Output units: electron (adu if doBootstrap=True)
         if self.config.doCrosstalk:
             self.log.info("Applying crosstalk corrections to full amplifier region.")
+            if self.config.doBootstrap and numpy.any(crosstalk.fitGains != 0):
+                crosstalkGains = None
+            else:
+                crosstalkGains = gains
             self.crosstalk.run(
                 ccdExposure,
                 crosstalk=crosstalk,
                 isTrimmed=False,
-                gains=gains,
+                gains=crosstalkGains,
                 fullAmplifier=True,
                 badAmpDict=badAmpDict,
             )

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -843,19 +843,23 @@ class IsrTaskLSST(pipeBase.PipelineTask):
                         serialOverscan = SerialOverscanCorrectionTask(config=ampConfig.serialOverscanConfig)
                         results = serialOverscan.run(ccdExposure, amp)
                     else:
+                        config = ampConfig.parallelOverscanConfig
                         parallelOverscan = ParallelOverscanCorrectionTask(
-                            config=ampConfig.parallelOverscanConfig,
+                            config=config,
                         )
 
                         # We need to know the saturation level that was used
                         # for the parallel overscan masking. If it isn't set
                         # then the configured parallelOverscanSaturationLevel
                         # will be used instead (assuming
-                        # doParallelOverscanSaturation is True).
+                        # doParallelOverscanSaturation is True). Note that
+                        # this will have the correct units (adu or electron)
+                        # depending on whether the gain has been applied.
                         if self.config.doSaturation:
                             saturationLevel = ccdExposure.metadata[
                                 f"LSST ISR SATURATION LEVEL {amp.getName()}"
                             ]
+                            saturationLevel *= config.parallelOverscanSaturationLevelAdjustmentFactor
                         else:
                             saturationLevel = None
 

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -1641,6 +1641,7 @@ class IsrTaskLSST(pipeBase.PipelineTask):
                 isTrimmed=False,
                 gains=gains,
                 fullAmplifier=True,
+                badAmpDict=badAmpDict,
             )
 
         # Parallel overscan correction.

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -1042,8 +1042,14 @@ class IsrTaskLSST(pipeBase.PipelineTask):
         if numNans > 0:
             self.log.warning("There were %d unmasked NaNs.", numNans)
 
-    def countBadPixels(self, exposure):
-        """
+    def setBadRegions(self, exposure):
+        """Set bad regions from large contiguous regions.
+
+        Parameters
+        ----------
+        exposure : `lsst.afw.Exposure`
+            Exposure to set bad regions.
+
         Notes
         -----
         Reset and interpolate bad pixels.
@@ -1770,8 +1776,8 @@ class IsrTaskLSST(pipeBase.PipelineTask):
             preInterpExp = ccdExposure.clone()
 
         if self.config.doSetBadRegions:
-            self.log.info('Counting pixels in BAD regions.')
-            self.countBadPixels(ccdExposure)
+            self.log.info('Setting values in large contiguous bad regions.')
+            self.setBadRegions(ccdExposure)
 
         if self.config.doInterpolate:
             self.log.info("Interpolating masked pixels.")

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -107,6 +107,13 @@ class IsrTaskLSSTConnections(pipeBase.PipelineTaskConnections,
         dimensions=["instrument", "detector"],
         isCalibration=True,
     )
+    flat = cT.PrerequisiteInput(
+        name="flat",
+        doc="Input flat calibration.",
+        storageClass="ExposureF",
+        dimensions=["instrument", "detector", "physical_filter"],
+        isCalibration=True,
+    )
     outputExposure = cT.Output(
         name='postISRCCD',
         doc="Output ISR processed exposure.",
@@ -160,6 +167,8 @@ class IsrTaskLSSTConnections(pipeBase.PipelineTaskConnections,
             del self.bfKernel
         if config.doDark is not True:
             del self.dark
+        if config.doFlat is not True:
+            del self.flat
 
         if config.doBinnedExposures is not True:
             del self.outputBin1Exposure
@@ -1461,7 +1470,7 @@ class IsrTaskLSST(pipeBase.PipelineTask):
             self.compareCameraKeywords(exposureMetadata, bfKernel, "brighter-fatter")
         if self.config.doFlat:
             if flat is None:
-                raise RuntimeError("doFlat is True but not flat provided.")
+                raise RuntimeError("doFlat is True but no flat provided.")
             self.compareCameraKeywords(exposureMetadata, flat, "flat")
 
         # FIXME: Make sure that if linearity is done then it is matched

--- a/python/lsst/ip/isr/linearize.py
+++ b/python/lsst/ip/isr/linearize.py
@@ -821,7 +821,7 @@ class LinearizeSpline(LinearizeBase):
                                          afwMath.stringToInterpStyle("AKIMA_SPLINE"))
 
         ampArr = image.getArray()
-        delta = interp.interpolate(ampArr.flatten())
+        delta = interp.interpolate(ampArr.ravel())
         ampArr -= np.array(delta).reshape(ampArr.shape)
 
         return True, 0

--- a/python/lsst/ip/isr/overscan.py
+++ b/python/lsst/ip/isr/overscan.py
@@ -1163,8 +1163,17 @@ class ParallelOverscanCorrectionTaskConfig(OverscanCorrectionTaskConfigBase):
     parallelOverscanSaturationLevel = pexConfig.Field(
         dtype=float,
         doc="The saturation level (adu) to use if not specified in call to "
-            "maskParallelOverscan.",
-        default=100000.,
+            "maskParallelOverscanAmp. This should be low enough to capture "
+            "all possible amplifiers for defect detection.",
+        default=20000.,
+    )
+    parallelOverscanSaturationLevelAdjustmentFactor = pexConfig.Field(
+        dtype=float,
+        doc="The parallel overscan saturation level may be below that of "
+            "the data region. This factor is applied to the amplifier "
+            "saturation value when evaluating saturation in the parallel "
+            "overscan region.",
+        default=0.75,
     )
     parallelOverscanMaskGrowSize = pexConfig.Field(
         dtype=int,

--- a/python/lsst/ip/isr/overscan.py
+++ b/python/lsst/ip/isr/overscan.py
@@ -155,7 +155,8 @@ class OverscanCorrectionTaskBase(pipeBase.Task):
         raise NotImplementedError("run method is not defined for OverscanCorrectionTaskBase")
 
     def correctOverscan(self, exposure, amp, imageBBox, overscanBBox,
-                        isTransposed=True, leadingToSkip=0, trailingToSkip=0):
+                        isTransposed=True, leadingToSkip=0, trailingToSkip=0,
+                        overscanFraction=1.0, imageThreshold=np.inf):
         """Trim the exposure, fit the overscan, subtract the fit, and
         calculate statistics.
 
@@ -179,6 +180,14 @@ class OverscanCorrectionTaskBase(pipeBase.Task):
             Leading rows/columns to skip.
         trailingToSkip : `int`, optional
             Leading rows/columns to skip.
+        overscanFraction : `float`, optional
+            If the overscan region median is greater than overscanFraction
+            and the imaging region median is greater than imageThreshold
+            then overscan correction will be skipped.
+        maxLevel : `float`, optional
+            If the overscan region median is greater than overscanFraction
+            and the imaging region median is greater than imageThreshold
+            then overscan correction will be skipped.
 
         Returns
         -------
@@ -221,12 +230,28 @@ class OverscanCorrectionTaskBase(pipeBase.Task):
         maskVal = overscanImage.mask.getPlaneBitMask(self.config.maskPlanes)
         overscanMask = ~((overscanImage.mask.array & maskVal) == 0)
 
+        badResults = False
+        overscanMedian = np.nanmedian(overscanImage.image.array)
+        imageMedian = np.nanmedian(exposure[imageBBox].image.array)
+
         if np.all(overscanMask):
             self.log.warning(
                 "All overscan pixels masked when attempting overscan correction for %s",
                 amp.getName(),
             )
+            badResults = True
+        elif overscanMedian/imageMedian > overscanFraction and imageMedian > imageThreshold:
+            self.log.warning(
+                "The level in the overscan region (%.2f) compared to the image region (%.2f) is "
+                "greater than the maximum fraction (%.2f) for %s",
+                overscanMedian,
+                imageMedian,
+                overscanFraction,
+                amp.getName(),
+            )
+            badResults = True
 
+        if badResults:
             # Do not do overscan subtraction at all.
             overscanResults = pipeBase.Struct(
                 overscanValue=0.0,
@@ -1137,7 +1162,7 @@ class ParallelOverscanCorrectionTaskConfig(OverscanCorrectionTaskConfigBase):
     )
     parallelOverscanSaturationLevel = pexConfig.Field(
         dtype=float,
-        doc="The saturation level to use if not specified in call to "
+        doc="The saturation level (adu) to use if not specified in call to "
             "maskParallelOverscan.",
         default=100000.,
     )
@@ -1157,6 +1182,22 @@ class ParallelOverscanCorrectionTaskConfig(OverscanCorrectionTaskConfigBase):
         dtype=int,
         doc="Number of trailing values to skip in parallel overscan correction.",
         default=0,
+    )
+    parallelOverscanFraction = pexConfig.Field(
+        dtype=float,
+        doc="When the parallel overscan region median is greater than parallelOverscanFraction "
+            "and the imaging region median is greater than parallelOverscanImageThreshold "
+            "then parallel overscan subtraction will be turned off, as this is usually "
+            "due to the region being flooded with spillover from a super-saturated flat.",
+        default=0.5,
+    )
+    parallelOverscanImageThreshold = pexConfig.Field(
+        dtype=float,
+        doc="When the parallel overscan region median is greater than parallelOverscanFraction "
+            "and the imaging region median is greater than parallelOverscanImageThreshold "
+            "then parallel overscan subtraction will be turned off, as this is usually "
+            "due to the region being flooded with spillover from a super-saturated flat.",
+        default=10000.0,
     )
 
 
@@ -1247,6 +1288,8 @@ class ParallelOverscanCorrectionTask(OverscanCorrectionTaskBase):
             isTransposed=not isTransposed,
             leadingToSkip=self.config.leadingToSkip,
             trailingToSkip=self.config.trailingToSkip,
+            overscanFraction=self.config.parallelOverscanFraction,
+            imageThreshold=self.config.parallelOverscanImageThreshold,
         )
         overscanMean = results.overscanMean
         overscanMedian = results.overscanMedian

--- a/python/lsst/ip/isr/overscan.py
+++ b/python/lsst/ip/isr/overscan.py
@@ -1253,7 +1253,7 @@ class ParallelOverscanCorrectionTask(OverscanCorrectionTaskBase):
             residualSigma=residualSigma,
         )
 
-    def maskParallelOverscan(self, exposure, detector, saturationLevel=None):
+    def maskParallelOverscanAmp(self, exposure, amp, saturationLevel=None):
         """Mask parallel overscan, growing saturated pixels.
 
         This operates on the image in-place.
@@ -1262,8 +1262,8 @@ class ParallelOverscanCorrectionTask(OverscanCorrectionTaskBase):
         ----------
         exposure : `lsst.afw.image.Exposure`
             An untrimmed raw exposure.
-        detector : `lsst.afw.cameraGeom.Detector`
-            The detetor to use for amplifier geometry.
+        amp : `lsst.afw.cameraGeom.Amplifier`
+            The amplifier to use for masking.
         saturationLevel : `float`, optional
             Saturation level to use for masking.
         """
@@ -1274,13 +1274,12 @@ class ParallelOverscanCorrectionTask(OverscanCorrectionTaskBase):
         if saturationLevel is None:
             saturationLevel = self.config.parallelOverscanSaturationLevel
 
-        for amp in detector:
-            dataView = afwImage.MaskedImageF(exposure.getMaskedImage(),
-                                             amp.getRawParallelOverscanBBox(),
-                                             afwImage.PARENT)
-            makeThresholdMask(
-                maskedImage=dataView,
-                threshold=saturationLevel,
-                growFootprints=self.config.parallelOverscanMaskGrowSize,
-                maskName="BAD"
-            )
+        dataView = afwImage.MaskedImageF(exposure.getMaskedImage(),
+                                         amp.getRawParallelOverscanBBox(),
+                                         afwImage.PARENT)
+        makeThresholdMask(
+            maskedImage=dataView,
+            threshold=saturationLevel,
+            growFootprints=self.config.parallelOverscanMaskGrowSize,
+            maskName="BAD",
+        )

--- a/python/lsst/ip/isr/overscan.py
+++ b/python/lsst/ip/isr/overscan.py
@@ -266,12 +266,12 @@ class OverscanCorrectionTaskBase(pipeBase.Task):
             )
         else:
             median = np.ma.median(np.ma.masked_where(overscanMask, overscanArray))
-            bad = np.where(np.abs(overscanArray - median) > self.config.maxDeviation)
+            bad = np.where((np.abs(overscanArray - median) > self.config.maxDeviation) & (~overscanMask))
             # Mark the bad pixels as BAD.
             overscanImage.mask.array[bad] = overscanImage.mask.getPlaneBitMask("BAD")
 
             # Check for completely masked row/column.
-            if maskedRowColumnGrowSize > 0:
+            if maskedRowColumnGrowSize > 0 and len(bad) > 0:
                 if isTransposed:
                     axis = 0
                     nComp = overscanArray.shape[0]

--- a/python/lsst/ip/isr/overscanAmpConfig.py
+++ b/python/lsst/ip/isr/overscanAmpConfig.py
@@ -66,6 +66,9 @@ class OverscanAmpConfig(pexConfig.Config):
         self.parallelOverscanConfig.leadingToSkip = 3
         self.parallelOverscanConfig.trailingToSkip = 3
         self.parallelOverscanConfig.overscanIsInt = False
+        # We expect the parallel overscan to not deviate much
+        # after serial overscan subtraction and crosstalk correction.
+        self.parallelOverscanConfig.maxDeviation = 100.0
 
     @property
     def _stringForHash(self):

--- a/python/lsst/ip/isr/vignette.py
+++ b/python/lsst/ip/isr/vignette.py
@@ -57,13 +57,6 @@ class VignetteConfig(Config):
         doc="Number of points used to define the vignette polygon.",
         default=100,
     )
-    doWriteVignettePolygon = Field(
-        dtype=bool,
-        doc="Persist polygon used to define vignetted region?",
-        default=False,
-        deprecated=("Vignetted polygon is added to the exposure by default."
-                    " This option is no longer used, and will be removed after v24.")
-    )
 
 
 class VignetteTask(Task):

--- a/tests/test_isrMisc.py
+++ b/tests/test_isrMisc.py
@@ -54,7 +54,6 @@ class IsrMiscCases(lsst.utils.tests.TestCase):
         config.xCenter = 0.0
         config.yCenter = 100.0
 
-        config.doWriteVignettePolygon = True
         task = vignette.VignetteTask(config=config)
         result = task.run(self.inputExp)
 

--- a/tests/test_isrTaskLSST.py
+++ b/tests/test_isrTaskLSST.py
@@ -360,6 +360,9 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
         """Test processing of a dark frame."""
         mock_config = self.get_mock_config_no_signal()
         mock_config.doAddDark = True
+        # We turn off the bad parallel overscan column because it does
+        # add more noise to that region.
+        mock_config.doAddBadParallelOverscanColumn = False
 
         mock = isrMockLSST.IsrMockLSST(config=mock_config)
         input_exp = mock.run()
@@ -411,7 +414,7 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
         # factor for the extra noise from the overscan subtraction.
         self.assertLess(
             np.std(result.exposure.image.array[good_pixels]),
-            1.5*np.sqrt(mock_config.darkRate*mock_config.expTime + mock_config.readNoise),
+            1.6*np.sqrt(mock_config.darkRate*mock_config.expTime + mock_config.readNoise),
         )
 
         delta = result2.exposure.image.array - result.exposure.image.array
@@ -698,7 +701,7 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
 
         # We compare the good pixels in the entirety.
         self.assertLess(np.std(delta[good_pixels]), 5.0)
-        self.assertLess(np.max(np.abs(delta[good_pixels])), 5.0*5)
+        self.assertLess(np.max(np.abs(delta[good_pixels])), 5.0*7)
 
         # Make sure the corrected image is overall consistent with the
         # straight image.
@@ -825,7 +828,8 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
 
         # We compare the good pixels in the entirety.
         self.assertLess(np.std(delta[good_pixels]), 5.0)
-        self.assertLess(np.max(np.abs(delta[good_pixels])), 5.0*5)
+        # This is sensitive to parallel overscan masking.
+        self.assertLess(np.max(np.abs(delta[good_pixels])), 5.0*7)
 
         # Make sure the corrected image is overall consistent with the
         # straight image.

--- a/tests/test_isrTaskLSST.py
+++ b/tests/test_isrTaskLSST.py
@@ -142,7 +142,7 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
 
         metadata = result.exposure.metadata
 
-        key = "LSST ISR NOMINAL PTC USED"
+        key = "LSST ISR BOOTSTRAP"
         self.assertIn(key, metadata)
         self.assertEqual(metadata[key], True)
 
@@ -158,7 +158,7 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
             amp_name = amp.getName()
             key = f"LSST ISR GAIN {amp_name}"
             self.assertIn(key, metadata)
-            self.assertEqual(metadata[key], isr_config.nominalGain)
+            self.assertEqual(metadata[key], 1.0)
             key = f"LSST ISR SATURATION LEVEL {amp_name}"
             self.assertIn(key, metadata)
             self.assertEqual(metadata[key], self.saturation_adu)
@@ -218,7 +218,7 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
 
         metadata = result.exposure.metadata
 
-        key = "LSST ISR NOMINAL PTC USED"
+        key = "LSST ISR BOOTSTRAP"
         self.assertIn(key, metadata)
         self.assertEqual(metadata[key], True)
 
@@ -317,7 +317,7 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
 
         metadata = result.exposure.metadata
 
-        key = "LSST ISR NOMINAL PTC USED"
+        key = "LSST ISR BOOTSTRAP"
         self.assertIn(key, metadata)
         self.assertEqual(metadata[key], True)
 
@@ -750,7 +750,7 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
 
         metadata = result.exposure.metadata
 
-        key = "LSST ISR NOMINAL PTC USED"
+        key = "LSST ISR BOOTSTRAP"
         self.assertIn(key, metadata)
         self.assertEqual(metadata[key], False)
 

--- a/tests/test_isrTaskLSST.py
+++ b/tests/test_isrTaskLSST.py
@@ -1080,7 +1080,7 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
 
         # The levels are set in electron units.
         # We test 3 levels:
-        #  * 1000.0, a lowish but outlier level (with no neighbor flux).
+        #  * 1000.0, a lowish but outlier level.
         #  * 1.05*saturation.
         # Note that the default parallel overscan saturation level for
         # bootstrap (pre-saturation-measure) analysis is very low, in
@@ -1093,9 +1093,6 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
 
         for level in levels:
             mock_config.badParallelOverscanColumnLevel = level
-            mock_config.doAddBadParallelOverscanColumnNeighbors = False
-            if (level - mock_config.clockInjectedOffsetLevel) > overscan_sat_level:
-                mock_config.doAddBadParallelOverscanColumnNeighbors = True
             mock = isrMockLSST.IsrMockLSST(config=mock_config)
             input_exp = mock.run()
 
@@ -1118,7 +1115,7 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
                     neighbor_image = result.exposure[bbox_neighbor].image.array
 
                     neighbor_median = np.median(neighbor_image)
-                    self.assertFloatsAlmostEqual(neighbor_median, 0.0, atol=5.0)
+                    self.assertFloatsAlmostEqual(neighbor_median, 0.0, atol=7.0)
 
     def test_isrBadParallelOverscanColumns(self):
         """Test processing a bias when we have a bad parallel overscan column.
@@ -1140,7 +1137,7 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
 
         # The levels are set in electron units.
         # We test 3 levels:
-        #  * 1000.0, a lowish but outlier level (with no neighbor flux).
+        #  * 1000.0, a lowish but outlier level.
         #  * 0.9*saturation, following ITL-style parallel overscan bleeds.
         #  * 1.05*saturation, following E2V-style parallel overscan bleeds.
         levels = mock_config.clockInjectedOffsetLevel + np.array(
@@ -1149,9 +1146,6 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
 
         for level in levels:
             mock_config.badParallelOverscanColumnLevel = level
-            mock_config.doAddBadParallelOverscanColumnNeighbors = False
-            if (level - mock_config.clockInjectedOffsetLevel) > 0.8*sat_level:
-                mock_config.doAddBadParallelOverscanColumnNeighbors = True
             mock = isrMockLSST.IsrMockLSST(config=mock_config)
             input_exp = mock.run()
 
@@ -1179,7 +1173,7 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
                     neighbor_image = result.exposure[bbox_neighbor].image.array
 
                     neighbor_median = np.median(neighbor_image)
-                    self.assertFloatsAlmostEqual(neighbor_median, 0.0, atol=5.0)
+                    self.assertFloatsAlmostEqual(neighbor_median, 0.0, atol=7.0)
 
     def test_isrBadPtcGain(self):
         """Test processing when an amp has a bad (nan) PTC gain.

--- a/tests/test_isrTaskLSST.py
+++ b/tests/test_isrTaskLSST.py
@@ -26,6 +26,7 @@ import numpy as np
 import logging
 import galsim
 
+import lsst.geom as geom
 import lsst.ip.isr.isrMockLSST as isrMockLSST
 import lsst.utils.tests
 from lsst.ip.isr.isrTaskLSST import (IsrTaskLSST, IsrTaskLSSTConfig)
@@ -841,9 +842,13 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
         # trail.
         self.assertLess(np.std(delta), 7.0)
 
-    def test_isrFloodedSaturated(self):
-        """Test ISR when the amps are completely flooded and
-        the parallel overscan region is also flooded.
+    def test_isrFloodedSaturatedE2V(self):
+        """Test ISR when the amps are completely saturated.
+
+        This version tests what happens when the parallel overscan
+        region is flooded like E2V detectors, where the saturation
+        spreads evenly, but at a greater level than the saturation
+        value.
         """
         # We are simulating a flat field.
         # Note that these aren't very important because we are replacing
@@ -880,15 +885,116 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
                 data_level = (parallel_overscan_saturation * 1.05
                               + mock_config.biasLevel
                               + mock_config.clockInjectedOffsetLevel)
-                parallel_overscan_level = (parallel_overscan_saturation * 1.01
+                parallel_overscan_level = (parallel_overscan_saturation * 1.1
                                            + mock_config.biasLevel
                                            + mock_config.clockInjectedOffsetLevel)
             else:
-                data_level = 0.9 * parallel_overscan_saturation
-                parallel_overscan_level = 0.75 * data_level
+                data_level = (parallel_overscan_saturation * 0.7
+                              + mock_config.biasLevel
+                              + mock_config.clockInjectedOffsetLevel)
+                parallel_overscan_level = (parallel_overscan_saturation * 0.75
+                                           + mock_config.biasLevel
+                                           + mock_config.clockInjectedOffsetLevel)
 
             input_exp[amp.getRawDataBBox()].image.array[:, :] = data_level
             input_exp[amp.getRawParallelOverscanBBox()].image.array[:, :] = parallel_overscan_level
+
+        isr_task = IsrTaskLSST(config=isr_config)
+        with self.assertLogs(level=logging.WARNING) as cm:
+            result = isr_task.run(
+                input_exp.clone(),
+                bias=self.bias_adu,
+                dark=self.dark_adu,
+            )
+        self.assertEqual(len(cm.records), len(detector))
+
+        n_all = 0
+        n_level = 0
+        for record in cm.records:
+            if "All overscan pixels masked" in record.message:
+                n_all += 1
+            if "The level in the overscan region" in record.message:
+                n_level += 1
+
+        self.assertEqual(n_all, len(detector) // 2)
+        self.assertEqual(n_level, len(detector) // 2)
+
+        # And confirm that the post-ISR levels are high for each amp.
+        for amp in detector:
+            med = np.median(result.exposure[amp.getBBox()].image.array)
+            self.assertGreater(med, 50000.0)
+
+    def test_isrFloodedSaturatedITL(self):
+        """Test ISR when the amps are completely saturated.
+
+        This version tests what happens when the parallel overscan
+        region is flooded like ITL detectors, where the saturation
+        is at a lower level than the imaging region, and also
+        spreads partly into the serial/parallel region.
+        """
+        # We are simulating a flat field.
+        # Note that these aren't very important because we are replacing
+        # the flux, but we may as well.
+        mock_config = self.get_mock_config_no_signal()
+        mock_config.doAddDark = True
+        mock_config.doAddFlat = True
+        # The doAddSky option adds the equivalent of flat-field flux.
+        mock_config.doAddSky = True
+
+        mock = isrMockLSST.IsrMockLSST(config=mock_config)
+        input_exp = mock.run()
+
+        isr_config = self.get_isr_config_minimal_corrections()
+        isr_config.doBootstrap = True
+        isr_config.doApplyGains = False
+        isr_config.doBias = True
+        isr_config.doDark = True
+        isr_config.doFlat = False
+        # Tun off saturation masking to simulate a PTC flat.
+        isr_config.doSaturation = False
+
+        amp_config = isr_config.overscanCamera.defaultDetectorConfig.defaultAmpConfig
+        parallel_overscan_saturation = amp_config.parallelOverscanConfig.parallelOverscanSaturationLevel
+
+        detector = input_exp.getDetector()
+        for i, amp in enumerate(detector):
+            # For half of the amps we are testing what happens when the
+            # parallel overscan region is above the configured saturation
+            # level; for the other half we are testing the other branch
+            # when it saturates below this level (which is a priori
+            # unknown).
+            if i < len(detector) // 2:
+                data_level = (parallel_overscan_saturation * 1.1
+                              + mock_config.biasLevel
+                              + mock_config.clockInjectedOffsetLevel)
+                parallel_overscan_level = (parallel_overscan_saturation * 1.05
+                                           + mock_config.biasLevel
+                                           + mock_config.clockInjectedOffsetLevel)
+            else:
+                data_level = (parallel_overscan_saturation * 0.75
+                              + mock_config.biasLevel
+                              + mock_config.clockInjectedOffsetLevel)
+                parallel_overscan_level = (parallel_overscan_saturation * 0.7
+                                           + mock_config.biasLevel
+                                           + mock_config.clockInjectedOffsetLevel)
+
+            input_exp[amp.getRawDataBBox()].image.array[:, :] = data_level
+            input_exp[amp.getRawParallelOverscanBBox()].image.array[:, :] = parallel_overscan_level
+            # The serial/parallel region for the test camera looks like this:
+            serial_overscan_bbox = amp.getRawSerialOverscanBBox()
+            parallel_overscan_bbox = amp.getRawParallelOverscanBBox()
+
+            overscan_corner_bbox = geom.Box2I(
+                geom.Point2I(
+                    serial_overscan_bbox.getMinX(),
+                    parallel_overscan_bbox.getMinY(),
+                ),
+                geom.Extent2I(
+                    serial_overscan_bbox.getWidth(),
+                    parallel_overscan_bbox.getHeight(),
+                ),
+            )
+            input_exp[overscan_corner_bbox].image.array[-2:, :] = parallel_overscan_level
 
         isr_task = IsrTaskLSST(config=isr_config)
         with self.assertLogs(level=logging.WARNING) as cm:

--- a/tests/test_isrTaskLSST.py
+++ b/tests/test_isrTaskLSST.py
@@ -163,7 +163,7 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
             self.assertIn(key, metadata)
             self.assertEqual(metadata[key], self.saturation_adu)
 
-        self._check_bad_column_crosstalk_correction(result.exposure, units="adu")
+        self._check_bad_column_crosstalk_correction(result.exposure)
 
     def test_isrBootstrapDark(self):
         """Test processing of a ``bootstrap`` dark frame.
@@ -226,7 +226,7 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
         self.assertIn(key, metadata)
         self.assertEqual(metadata[key], "adu")
 
-        self._check_bad_column_crosstalk_correction(result.exposure, units="adu")
+        self._check_bad_column_crosstalk_correction(result.exposure)
 
     def test_isrBootstrapFlat(self):
         """Test processing of a ``bootstrap`` flat frame.
@@ -325,7 +325,7 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
         self.assertIn(key, metadata)
         self.assertEqual(metadata[key], "adu")
 
-        self._check_bad_column_crosstalk_correction(result.exposure, empirical_sigma=True, units="adu")
+        self._check_bad_column_crosstalk_correction(result.exposure)
 
     def test_isrBias(self):
         """Test processing of a bias frame."""
@@ -534,7 +534,7 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
         ratio = result2.exposure.image.array / result.exposure.image.array
         self.assertFloatsAlmostEqual(ratio, flat_nodefects.image.array, atol=1e-4)
 
-        self._check_bad_column_crosstalk_correction(result.exposure, empirical_sigma=True)
+        self._check_bad_column_crosstalk_correction(result.exposure)
 
     def test_isrNoise(self):
         """Test the recorded noise and gain in the metadata."""
@@ -1397,8 +1397,6 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
         self,
         exp,
         nsigma_cut=5.0,
-        empirical_sigma=False,
-        units="electron",
     ):
         """Test bad column crosstalk correction.
 
@@ -1413,19 +1411,10 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
             Input exposure.
         nsigma_cut : `float`, optional
             Number of sigma to check for outliers.
-        empirical_sigma : `bool`, optional
-            Use empirical sigma?  Otherwise use read noise.
-        units : `str`, optional
-            Image units?
         """
         amp = self.detector[0]
         amp_image = exp[amp.getBBox()].image.array
-        if empirical_sigma:
-            sigma = median_abs_deviation(amp_image.ravel(), scale="normal")
-        elif units == "electron":
-            sigma = self.ptc.noise[amp.getName()]
-        else:
-            sigma = self.ptc.noise[amp.getName()] / self.ptc.gain[amp.getName()]
+        sigma = median_abs_deviation(amp_image.ravel(), scale="normal")
 
         med = np.median(amp_image.ravel())
         self.assertLess(amp_image.max(), med + nsigma_cut*sigma)

--- a/tests/test_overscanCorrection.py
+++ b/tests/test_overscanCorrection.py
@@ -548,8 +548,13 @@ class IsrTestCases(lsst.utils.tests.TestCase):
                     parallelOverscanTask = ipIsr.overscan.ParallelOverscanCorrectionTask(
                         config=configParallel,
                     )
-                    # This next line is usually run as part of IsrTask
-                    parallelOverscanTask.maskParallelOverscan(exposureCopy, detector, saturationLevel=100000.)
+                    # This next line is usually run as part of IsrTaskLSST.
+                    for amp in detector:
+                        parallelOverscanTask.maskParallelOverscanAmp(
+                            exposureCopy,
+                            amp,
+                            saturationLevel=100000.,
+                        )
                     oscanResults = parallelOverscanTask.run(exposureCopy, amp)
 
                 self.assertIsInstance(oscanResults, pipeBase.Struct)

--- a/tests/test_overscanCorrection.py
+++ b/tests/test_overscanCorrection.py
@@ -543,6 +543,7 @@ class IsrTestCases(lsst.utils.tests.TestCase):
 
                     configParallel = ipIsr.overscan.ParallelOverscanCorrectionTask.ConfigClass()
                     configParallel.parallelOverscanMaskGrowSize = 1
+                    configParallel.parallelOverscanMaskedColumnGrowSize = 0
                     configParallel.fitType = fitType
 
                     parallelOverscanTask = ipIsr.overscan.ParallelOverscanCorrectionTask(


### PR DESCRIPTION
This PR contains a number of updates to ip_isr based on testing of the new task and pipelines from DM-45856.  Aside from bug fixes and checks of invalid (nan) crosstalk matrix values, there are a large number of updates to the parallel overscan masking to ensure that (a) saturated flats don't get oversubtracted; (b) saturated and unsaturated defect bleeds into the parallel overscan region are handled correctly.

This also takes advantage of crosstalk `fitGains` to apply reasonable gain values when applying crosstalk corrections to bootstrap frames.