### PR TITLE
DM-46308: Update PTC dataset to 2.0 and add more fields and methods.

### DIFF
--- a/python/lsst/ip/isr/calibType.py
+++ b/python/lsst/ip/isr/calibType.py
@@ -129,13 +129,18 @@ class IsrCalib(abc.ABC):
                         # (it's not a number or array of numbers),
                         # then it needs to have its own equivalence
                         # operator.
-                        if attrSelf[key] != attrOther[key]:
+                        if np.all(attrSelf[key] != attrOther[key]):
                             return False
             elif isinstance(attrSelf, np.ndarray):
                 # Bare array.
-                if not np.allclose(attrSelf, attrOther, equal_nan=True):
-                    self.log.debug("Array Failure: %s %s %s", attr, attrSelf, attrOther)
-                    return False
+                if isinstance(attrSelf[0], (str, np.str_, np.string_)):
+                    if not np.all(attrSelf == attrOther):
+                        self.log.debug("Array Failure: %s %s %s", attr, attrSelf, attrOther)
+                        return False
+                else:
+                    if not np.allclose(attrSelf, attrOther, equal_nan=True):
+                        self.log.debug("Array Failure: %s %s %s", attr, attrSelf, attrOther)
+                        return False
             elif type(attrSelf) is not type(attrOther):
                 if set([attrSelf, attrOther]) == set([None, ""]):
                     # Fits converts None to "", but None is not "".

--- a/python/lsst/ip/isr/ptcDataset.py
+++ b/python/lsst/ip/isr/ptcDataset.py
@@ -874,6 +874,64 @@ class PhotonTransferCurveDataset(IsrCalib):
 
         pass
 
+    def sort(self, sortIndex):
+        """Sort the components of the PTC by a given sort index.
+
+        The PTC is sorted in-place.
+
+        Parameters
+        ----------
+        sortIndex : `list` or `np.ndarray`
+            The sorting index, which must be the same length as
+            the number of elements of the PTC.
+        """
+        index = np.atleast_1d(sortIndex)
+
+        # First confirm everything matches.
+        for ampName in self.ampNames:
+            if len(index) != len(self.rawExpTimes[ampName]):
+                raise ValueError(
+                    f"Length of sortIndex ({len(index)}) does not match number of PTC "
+                    f"elements ({len(self.rawExpTimes[ampName])})",
+                )
+
+        # Note that gain, gainUnadjusted, gainErr, noise, noiseErr,
+        # ptcTurnoff, ptcTurnoffSamplingError, and the full covariance fit
+        # parameters are global and not sorted by input pair.
+
+        for ampName in self.ampNames:
+            self.inputExpIdPairs[ampName] = np.array(
+                self.inputExpIdPairs[ampName]
+            )[index].tolist()
+
+            self.expIdMask[ampName] = self.expIdMask[ampName][index]
+            self.rawExpTimes[ampName] = self.rawExpTimes[ampName][index]
+            self.rawMeans[ampName] = self.rawMeans[ampName][index]
+            self.rawVars[ampName] = self.rawVars[ampName][index]
+            self.rowMeanVariance[ampName] = self.rowMeanVariance[ampName][index]
+            self.photoCharges[ampName] = self.photoCharges[ampName][index]
+            self.ampOffsets[ampName] = self.ampOffsets[ampName][index]
+
+            self.gainList[ampName] = self.gainList[ampName][index]
+            self.noiseList[ampName] = self.noiseList[ampName][index]
+
+            self.histVars[ampName] = self.histVars[ampName][index]
+            self.histChi2Dofs[ampName] = self.histChi2Dofs[ampName][index]
+            self.kspValues[ampName] = self.kspValues[ampName][index]
+
+            self.covariances[ampName] = self.covariances[ampName][index]
+            self.covariancesSqrtWeights[ampName] = self.covariancesSqrtWeights[ampName][index]
+            self.covariancesModel[ampName] = self.covariancesModel[ampName][index]
+            self.covariancesModelNoB[ampName] = self.covariancesModelNoB[ampName][index]
+
+            self.finalVars[ampName] = self.finalVars[ampName][index]
+            self.finalModelVars[ampName] = self.finalModelVars[ampName][index]
+            self.finalMeans[ampName] = self.finalMeans[ampName][index]
+
+        # Sort the auxiliary values which are not stored per-amp.
+        for key, value in self.auxValues.items():
+            self.auxValues[key] = value[index]
+
     def getExpIdsUsed(self, ampName):
         """Get the exposures used, i.e. not discarded, for a given amp.
         If no mask has been created yet, all exposures are returned.

--- a/python/lsst/ip/isr/ptcDataset.py
+++ b/python/lsst/ip/isr/ptcDataset.py
@@ -101,10 +101,18 @@ class PhotonTransferCurveDataset(IsrCalib):
         Dictionary keyed by amp names containing the KS test p-value from
         fitting the difference image to a Gaussian model.
     gain : `dict`, [`str`, `float`]
-        Dictionary keyed by amp names containing the fitted gains.
+        Dictionary keyed by amp names containing the fitted gains. May be
+        adjusted by amp-offset gain ratios if configured in PTC solver.
+    gainUnadjusted : `dict`, [`str`, `float`]
+        Dictionary keyed by amp names containing unadjusted (raw) fit gain
+        values. May be the same as gain values if amp-offset adjustment
+        is not turned on.
     gainErr : `dict`, [`str`, `float`]
         Dictionary keyed by amp names containing the errors on the
         fitted gains.
+    gainList : `dict`, [`str`, `np.ndarray`]
+        Dictionary keyed by amp names containing the gain estimated from
+        each flat pair.
     noiseList : `dict`, [`str`, `np.ndarray`]
         Dictionary keyed by amp names containing the mean overscan
         standard deviation from each flat pair (units: adu).
@@ -186,7 +194,7 @@ class PhotonTransferCurveDataset(IsrCalib):
 
     Version 1.1 adds the `ptcTurnoff` attribute.
     Version 1.2 adds the `histVars`, `histChi2Dofs`, and `kspValues`
-    attributes.
+        attributes.
     Version 1.3 adds the `noiseMatrix` and `noiseMatrixNoB` attributes.
     Version 1.4 adds the `auxValues` attribute.
     Version 1.5 adds the `covMatrixSideFullCovFit` attribute.
@@ -194,7 +202,8 @@ class PhotonTransferCurveDataset(IsrCalib):
     Version 1.7 adds the `noiseList` attribute.
     Version 1.8 adds the `ptcTurnoffSamplingError` attribute.
     Version 1.9 standardizes PTC noise units to electron.
-    Version 2.0 adds the `ampOffset` attribute.
+    Version 2.0 adds the `ampOffsets`, `gainUnadjusted`, and
+        `gainList` attributes.
     """
 
     _OBSTYPE = 'PTC'
@@ -223,7 +232,9 @@ class PhotonTransferCurveDataset(IsrCalib):
         self.ampOffsets = {ampName: np.array([]) for ampName in ampNames}
 
         self.gain = {ampName: np.nan for ampName in ampNames}
+        self.gainUnadjusted = {ampName: np.nan for ampName in ampNames}
         self.gainErr = {ampName: np.nan for ampName in ampNames}
+        self.gainList = {ampName: np.array([]) for ampName in ampNames}
         self.noiseList = {ampName: np.array([]) for ampName in ampNames}
         self.noise = {ampName: np.nan for ampName in ampNames}
         self.noiseErr = {ampName: np.nan for ampName in ampNames}
@@ -265,7 +276,7 @@ class PhotonTransferCurveDataset(IsrCalib):
                                         'aMatrix', 'bMatrix', 'noiseMatrix', 'noiseMatrixNoB', 'finalVars',
                                         'finalModelVars', 'finalMeans', 'photoCharges', 'histVars',
                                         'histChi2Dofs', 'kspValues', 'auxValues', 'ptcTurnoffSamplingError',
-                                        'ampOffsets'])
+                                        'ampOffsets', 'gainUnadjusted', 'gainList'])
 
         self.updateMetadata(setCalibInfo=True, setCalibId=True, **kwargs)
         self._validateCovarianceMatrizSizes()
@@ -349,7 +360,10 @@ class PhotonTransferCurveDataset(IsrCalib):
         self.covariances[ampName] = np.array([covariance])
         self.covariancesSqrtWeights[ampName] = np.array([covSqrtWeights])
         self.gain[ampName] = gain
+        self.gainUnadjusted[ampName] = gain
+        self.gainList[ampName] = np.array([gain])
         self.noise[ampName] = noise
+        self.noiseList[ampName] = np.array([noise])
         self.histVars[ampName] = np.array([histVar])
         self.histChi2Dofs[ampName] = np.array([histChi2Dof])
         self.kspValues[ampName] = np.array([kspValue])
@@ -440,6 +454,8 @@ class PhotonTransferCurveDataset(IsrCalib):
                                                       dtype=np.float64)
             calib.gain[ampName] = float(dictionary['gain'][ampName])
             calib.gainErr[ampName] = float(dictionary['gainErr'][ampName])
+            calib.gainUnadjusted[ampName] = float(dictionary['gainUnadjusted'][ampName])
+            calib.gainList[ampName] = np.array(dictionary['gainList'][ampName], dtype=np.float64)
             calib.noiseList[ampName] = np.array(dictionary['noiseList'][ampName], dtype=np.float64)
             calib.noise[ampName] = float(dictionary['noise'][ampName])
             calib.noiseErr[ampName] = float(dictionary['noiseErr'][ampName])
@@ -543,6 +559,8 @@ class PhotonTransferCurveDataset(IsrCalib):
         outDict['rowMeanVariance'] = _dictOfArraysToDictOfLists(self.rowMeanVariance)
         outDict['gain'] = self.gain
         outDict['gainErr'] = self.gainErr
+        outDict['gainUnadjusted'] = self.gainUnadjusted
+        outDict['gainList'] = _dictOfArraysToDictOfLists(self.gainList)
         outDict['noiseList'] = _dictOfArraysToDictOfLists(self.noiseList)
         outDict['noise'] = self.noise
         outDict['noiseErr'] = self.noiseErr
@@ -606,6 +624,8 @@ class PhotonTransferCurveDataset(IsrCalib):
         inDict['rowMeanVariance'] = dict()
         inDict['gain'] = dict()
         inDict['gainErr'] = dict()
+        inDict['gainUnadjusted'] = dict()
+        inDict['gainList'] = dict()
         inDict['noiseList'] = dict()
         inDict['noise'] = dict()
         inDict['noiseErr'] = dict()
@@ -727,8 +747,12 @@ class PhotonTransferCurveDataset(IsrCalib):
                 inDict['noise'][ampName] = np.sqrt(record['noise'][ampName])
             if calibVersion < 2.0:
                 inDict['ampOffsets'][ampName] = np.full_like(inDict['rawMeans'][ampName], np.nan)
+                inDict['gainUnadjusted'][ampName] = record['GAIN']
+                inDict['gainList'][ampName] = np.full_like(inDict['rawMeans'][ampName], np.nan)
             else:
                 inDict['ampOffsets'][ampName] = record['AMP_OFFSETS']
+                inDict['gainUnadjusted'][ampName] = record['GAIN_UNADJUSTED']
+                inDict['gainList'][ampName] = record['GAIN_LIST']
 
         inDict['auxValues'] = {}
         record = ptcTable[0]
@@ -772,6 +796,8 @@ class PhotonTransferCurveDataset(IsrCalib):
                 'ROW_MEAN_VARIANCE': self.rowMeanVariance[ampName],
                 'GAIN': self.gain[ampName],
                 'GAIN_ERR': self.gainErr[ampName],
+                'GAIN_UNADJUSTED': self.gainUnadjusted[ampName],
+                'GAIN_LIST': self.gainList[ampName],
                 'NOISE_LIST': self.noiseList[ampName],
                 'NOISE': self.noise[ampName],
                 'NOISE_ERR': self.noiseErr[ampName],

--- a/python/lsst/ip/isr/ptcDataset.py
+++ b/python/lsst/ip/isr/ptcDataset.py
@@ -209,6 +209,20 @@ class PhotonTransferCurveDataset(IsrCalib):
 
     _OBSTYPE = 'PTC'
     _SCHEMA = 'Gen3 Photon Transfer Curve'
+    # When adding a new field to update the version, be sure to update the
+    # following methods:
+    #  * __init__()
+    #  * fromDict()
+    #  * toDict()
+    #  * fromTable()
+    #  * toTable()
+    #  * setAmpValuesPartialDataset()
+    #  * appendPartialPtc()
+    #  * sort()
+    #  * _checkTypes() in test_ptcDataset.py
+    #  * test_ptcDataset() in test_ptcDataset.py
+    #  * test_ptcDatasetSort in test_ptcDataset.py
+    #  * test_ptcDatasetAppend in test_ptcDataset.py
     _VERSION = 2.0
 
     def __init__(self, ampNames=[], ptcFitType=None, covMatrixSide=1,

--- a/tests/test_ptcDataset.py
+++ b/tests/test_ptcDataset.py
@@ -136,7 +136,12 @@ class PtcDatasetCases(lsst.utils.tests.TestCase):
 
         for key, value in ptcDataset.auxValues.items():
             self.assertIsInstance(value, np.ndarray)
-            self.assertEqual(value.dtype, np.float64)
+            if key == "INTVAL":
+                self.assertEqual(value.dtype, np.int64)
+            elif key == "PROGRAM":
+                self.assertIsInstance(value[0], np.str_)
+            else:
+                self.assertEqual(value.dtype, np.float64)
 
     def test_emptyPtcDataset(self):
         """Test an empty PTC dataset."""
@@ -187,6 +192,8 @@ class PtcDatasetCases(lsst.utils.tests.TestCase):
                     {
                         "CCOBCURR": 1.0,
                         "CCDTEMP": 0.0,
+                        "PROGRAM": "BLOCK-000",
+                        "INTVAL": 7,
                     }
                 )
             self._checkTypes(partialDataset)
@@ -203,7 +210,7 @@ class PtcDatasetCases(lsst.utils.tests.TestCase):
             self.assertEqual(fromFits, partialDataset)
             self._checkTypes(fromFits)
 
-    def test_ptcDatset(self):
+    def test_ptcDataset(self):
         """Test of a full PTC dataset."""
         # Fill the dataset with made up data.
         nSignalPoints = 5
@@ -300,6 +307,8 @@ class PtcDatasetCases(lsst.utils.tests.TestCase):
                         localDataset.auxValues = {
                             "CCOBCURR": np.ones(nSignalPoints),
                             "CCDTEMP": np.zeros(nSignalPoints),
+                            "PROGRAM": np.full(nSignalPoints, "BLOCK-000"),
+                            "INTVAL": np.ones(nSignalPoints, dtype=np.int64),
                         }
 
                     self._checkTypes(localDataset)

--- a/tests/test_ptcDataset.py
+++ b/tests/test_ptcDataset.py
@@ -136,7 +136,9 @@ class PtcDatasetCases(lsst.utils.tests.TestCase):
 
         for key, value in ptcDataset.auxValues.items():
             self.assertIsInstance(value, np.ndarray)
-            if key == "INTVAL":
+            # This key is explicitly camelCase to ensure that this dataset
+            # can handle mixed-case names.
+            if key == "intVal":
                 self.assertEqual(value.dtype, np.int64)
             elif key == "PROGRAM":
                 self.assertIsInstance(value[0], np.str_)
@@ -188,12 +190,16 @@ class PtcDatasetCases(lsst.utils.tests.TestCase):
 
         for useAuxValues in [False, True]:
             if useAuxValues:
+                # This key is explicitly camelCase to ensure that this dataset
+                # can handle mixed-case names.
                 partialDataset.setAuxValuesPartialDataset(
                     {
                         "CCOBCURR": 1.0,
                         "CCDTEMP": 0.0,
                         "PROGRAM": "BLOCK-000",
-                        "INTVAL": 7,
+                        # This key is explicitly camelCase to ensure that this
+                        # dataset can handle mixed-case names.
+                        "intVal": 7,
                     }
                 )
             self._checkTypes(partialDataset)
@@ -308,7 +314,9 @@ class PtcDatasetCases(lsst.utils.tests.TestCase):
                             "CCOBCURR": np.ones(nSignalPoints),
                             "CCDTEMP": np.zeros(nSignalPoints),
                             "PROGRAM": np.full(nSignalPoints, "BLOCK-000"),
-                            "INTVAL": np.ones(nSignalPoints, dtype=np.int64),
+                            # This key is explicitly camelCase to ensure that
+                            # this dataset can handle mixed-case names.
+                            "intVal": np.ones(nSignalPoints, dtype=np.int64),
                         }
 
                     self._checkTypes(localDataset)


### PR DESCRIPTION
As discovered in development of DM-45856 the PTC dataset can be improved (now version 2.0 because that is the number after 1.9, not for any semantic versioning reasons).

* We should have the `gainList` to go with the `noiseList` which tracks the gain from flat pairs in the combined PTC
* We can now store string-based auxiliary metadata, including observation reason and science program.
* The PTC `sort` and `appendPartialPtc` methods are added so that the PTC solver in `cp_pipe` doesn't need to monkey with internals (and risk missing appending/sorting a field)
* A comment has been added to explicitly list which functions should be updated when a new field is added with a new PTC version.