### PR TITLE
DM-48251: Add bias and dark variance planes to IsrTaskLSST variance plane.

### DIFF
--- a/python/lsst/ip/isr/isrFunctions.py
+++ b/python/lsst/ip/isr/isrFunctions.py
@@ -418,7 +418,7 @@ def darkCorrection(maskedImage, darkMaskedImage, expScale, darkScale, invert=Fal
         maskedImage.scaledPlus(scale, darkMaskedImage)
 
 
-def updateVariance(maskedImage, gain, readNoise):
+def updateVariance(maskedImage, gain, readNoise, replace=True):
     """Set the variance plane based on the image plane.
 
     The maskedImage must have units of `adu` (if gain != 1.0) or
@@ -433,9 +433,15 @@ def updateVariance(maskedImage, gain, readNoise):
         The amplifier gain in electron/adu.
     readNoise : scalar
         The amplifier read noise in electron/pixel.
+    replace : `bool`, optional
+        Replace the current variance?  If False, the image
+        variance will be added to the current variance plane.
     """
-    var = maskedImage.getVariance()
-    var[:] = maskedImage.getImage()
+    var = maskedImage.variance
+    if replace:
+        var[:, :] = maskedImage.image
+    else:
+        var[:, :] += maskedImage.image
     var /= gain
     var += (readNoise/gain)**2
 

--- a/python/lsst/ip/isr/isrMockLSST.py
+++ b/python/lsst/ip/isr/isrMockLSST.py
@@ -759,6 +759,10 @@ class IsrMockLSST(IsrMock):
             else:
                 exposure.metadata["LSST ISR UNITS"] = "electron"
 
+            # Add a variance plane appropriate for a calibration frame.
+            # We take the absolute value for biases which have no signal.
+            exposure.variance.array[:, :] = np.abs(np.median(exposure.image.array)/10.)
+
         if self.config.doGenerateAmpDict:
             expDict = dict()
             for amp in exposure.getDetector():

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -1015,6 +1015,7 @@ class IsrTaskLSST(pipeBase.PipelineTask):
                     maskedImage=ampExposure.maskedImage,
                     gain=gain,
                     readNoise=readNoise,
+                    replace=False,
                 )
 
                 if self.config.qa is not None and self.config.qa.saveStats is True:

--- a/tests/test_isrTaskLSST.py
+++ b/tests/test_isrTaskLSST.py
@@ -294,6 +294,11 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
         expected_variance = result.exposure.image.clone()
         # We have to remove the flat-fielding from the image pixels.
         expected_variance.array *= self.flat_adu.image.array
+        # And add in the bias variance.
+        expected_variance.array += self.bias_adu.variance.array
+        # And add in the scaled dark variance.
+        scale = result.exposure.visitInfo.darkTime / self.dark_adu.visitInfo.darkTime
+        expected_variance.array += scale**2. * self.dark_adu.variance.array
         # And add the gain and read noise (in electron) per amp.
         for amp in self.detector:
             # We need to use the gain and read noise from the header
@@ -792,6 +797,11 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
         expected_variance = result.exposure.image.clone()
         # We have to remove the flat-fielding from the image pixels.
         expected_variance.array *= self.flat.image.array
+        # And add in the bias variance.
+        expected_variance.array += self.bias.variance.array
+        # And add in the scaled dark variance.
+        scale = result.exposure.visitInfo.darkTime / self.dark.visitInfo.darkTime
+        expected_variance.array += scale**2. * self.dark.variance.array
         # And add the read noise (in electrons) per amp.
         for amp in self.detector:
             gain = self.ptc.gain[amp.getName()]


### PR DESCRIPTION
This also adds appropriate tests that the calibration variance planes are being used.