### PR TITLE
DM-35396: Add calib date to dataset provenance

### DIFF
--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -589,6 +589,8 @@ class IsrTaskLSST(pipeBase.PipelineTask):
                     idValue = str(reference.id)
                     dateKey = f"LSST CALIB DATE {inputName.upper()}"
                     dateValue = self.extractCalibDate(inputs[inputName])
+                    if dateValue != "Unknown Unknown":
+                        butlerQC.add_additional_provenance(reference, {"calib date": dateValue})
 
                     exposureMetadata[runKey] = runValue
                     exposureMetadata[idKey] = idValue


### PR DESCRIPTION
Requires lsst/pipe_base#464