### PR TITLE
DM-11270: Please don't warn about zero points for exposure times of 0

### DIFF
--- a/python/lsst/ip/isr/isrTask.py
+++ b/python/lsst/ip/isr/isrTask.py
@@ -2763,7 +2763,10 @@ class IsrTask(pipeBase.PipelineTask):
             fluxMag0 = self.config.defaultFluxMag0T1
 
         expTime = exposure.getInfo().getVisitInfo().getExposureTime()
-        if not expTime > 0:  # handle NaN as well as <= 0
+        if expTime == 0.0:
+            self.log.debug("Received exposure with 0.0 expTime; skipping rough zero point.")
+            return
+        elif not expTime > 0:  # handle NaN as well as <= 0
             self.log.warning("Non-positive exposure time; skipping rough zero point.")
             return
 


### PR DESCRIPTION
I've demoted the message in this case to debug, so it can be caught if needed.
This doesn't trigger in `ci_cpp_gen3`, because this is only called in the old `IsrTask` code (`ci_cpp_gen3` has switched to the LSST specific version).