### PR TITLE
DM-50061: Remove use of afw footprints wherever possible.

### DIFF
--- a/python/lsst/ip/isr/crosstalk.py
+++ b/python/lsst/ip/isr/crosstalk.py
@@ -785,9 +785,8 @@ class CrosstalkCalib(IsrCalib):
         if not doSubtrahendMasking:
             # When we are not using subtrahend masking, we set the mask.
             thresholdBackground = self.calculateBackground(sourceMaskedImage, badPixels)
-            threshold = lsst.afw.detection.Threshold(minPixelToMask + thresholdBackground)
-            footprints = lsst.afw.detection.FootprintSet(sourceMaskedImage, threshold)
-            footprints.setMask(sourceMaskedImage.mask, crosstalkStr)
+            toMask = (sourceMaskedImage.image.array > (minPixelToMask + thresholdBackground))
+            sourceMaskedImage.mask.array[toMask] |= sourceMaskedImage.mask.getPlaneBitMask(crosstalkStr)
 
         crosstalk = sourceMaskedImage.mask.getPlaneBitMask(crosstalkStr)
 

--- a/python/lsst/ip/isr/crosstalk.py
+++ b/python/lsst/ip/isr/crosstalk.py
@@ -881,14 +881,8 @@ class CrosstalkCalib(IsrCalib):
                 ampData.image.array[:, :] -= background
                 self.log.debug(f"Subtrahend background level: {amp.getName()} {background}")
 
-            # Run detection twice to avoid needing an absolute value image
-            threshold = lsst.afw.detection.Threshold(minPixelToMask, polarity=True)
-            footprints = lsst.afw.detection.FootprintSet(subtrahend, threshold)
-            footprints.setMask(subtrahend.mask, crosstalkStr)
-
-            threshold = lsst.afw.detection.Threshold(minPixelToMask, polarity=False)
-            footprints = lsst.afw.detection.FootprintSet(subtrahend, threshold)
-            footprints.setMask(subtrahend.mask, crosstalkStr)
+            toMask = (subtrahend.image.array > minPixelToMask) | (subtrahend.image.array < -minPixelToMask)
+            subtrahend.mask.array[toMask] |= subtrahend.mask.getPlaneBitMask(crosstalkStr)
 
             # Put the backgrounds back.
             for amp in targetDetector:

--- a/python/lsst/ip/isr/isrMock.py
+++ b/python/lsst/ip/isr/isrMock.py
@@ -514,7 +514,7 @@ class IsrMock(pipeBase.Task):
                 exposure,
                 crosstalkCoeffs=-1*self.crosstalkCoeffs,
                 doSubtrahendMasking=True,
-                minPixelToMask=1e100,
+                minPixelToMask=np.inf,
                 ignoreVariance=True,
                 fullAmplifier=False,
             )

--- a/python/lsst/ip/isr/isrMockLSST.py
+++ b/python/lsst/ip/isr/isrMockLSST.py
@@ -774,7 +774,7 @@ class IsrMockLSST(IsrMock):
                 exposure,
                 crosstalkCoeffs=-1*self.crosstalkCoeffs,
                 doSubtrahendMasking=True,
-                minPixelToMask=1e100,
+                minPixelToMask=np.inf,
                 ignoreVariance=True,
                 fullAmplifier=True,
             )

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -788,7 +788,7 @@ class IsrTaskLSST(pipeBase.PipelineTask):
                     # Set to the default from the camera model.
                     limits.update({self.config.saturatedMaskName: amp.getSaturation()})
                 elif self.config.defaultSaturationSource == "NONE":
-                    limits.update({self.config.saturatedMaskName: 1e100})
+                    limits.update({self.config.saturatedMaskName: numpy.inf})
 
                 # And update if it is set in the config.
                 if math.isfinite(ampConfig.saturation):
@@ -802,7 +802,7 @@ class IsrTaskLSST(pipeBase.PipelineTask):
                     # Set to the default from the camera model.
                     limits.update({self.config.suspectMaskName: amp.getSuspectLevel()})
                 elif self.config.defaultSuspectSource == "NONE":
-                    limits.update({self.config.suspectMaskName: 1e100})
+                    limits.update({self.config.suspectMaskName: numpy.inf})
 
                 # And update if it set in the config.
                 if math.isfinite(ampConfig.suspectLevel):

--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -812,12 +812,8 @@ class IsrTaskLSST(pipeBase.PipelineTask):
             for maskName, maskThreshold in limits.items():
                 if not math.isnan(maskThreshold):
                     dataView = maskedImage.Factory(maskedImage, amp.getRawBBox())
-                    isrFunctions.makeThresholdMask(
-                        maskedImage=dataView,
-                        threshold=maskThreshold,
-                        growFootprints=0,
-                        maskName=maskName
-                    )
+                    toMask = (dataView.image.array > maskThreshold)
+                    dataView.mask.array[toMask] |= dataView.mask.getPlaneBitMask(maskName)
 
             # Determine if we've fully masked this amplifier with SUSPECT and
             # SAT pixels.


### PR DESCRIPTION
This speeds things up in the most pessimistic cases and [tbd] in the normal case.