### PR TITLE
DM-54543: Set variance plane in NO_DATA vignetted regions to a very large value.

### DIFF
--- a/python/lsst/ip/isr/isrTaskLSST.py
+++ b/python/lsst/ip/isr/isrTaskLSST.py
@@ -666,6 +666,12 @@ class IsrTaskLSSTConfig(pipeBase.PipelineTaskConfig,
         doc="If flatScalingType is 'USER' then scale flat by this amount; ignored otherwise.",
         default=1.0,
     )
+    noDataVariance = pexConfig.Field(
+        dtype=float,
+        doc="Value to fill for variance plane in NO_DATA regions (which are generally "
+            "inherited from the flat in fully vignetted regions.)",
+        default=1e10,
+    )
 
     # Calculate image quality statistics?
     doStandardStatistics = pexConfig.Field(
@@ -2613,7 +2619,7 @@ class IsrTaskLSST(pipeBase.PipelineTask):
 
                 noData = (ccdExposure.mask.array & ccdExposure.mask.getPlaneBitMask("NO_DATA")) > 0
                 ccdExposure.image.array[noData] = 0.0
-                ccdExposure.variance.array[noData] = 0.0
+                ccdExposure.variance.array[noData] = self.config.noDataVariance
 
             ccdExposure.metadata["LSST ISR FLAT APPLIED"] = True
             ccdExposure.metadata["LSST ISR FLAT SOURCE"] = flat.metadata.get("FLATSRC", "UNKNOWN")

--- a/tests/test_isrTaskLSST.py
+++ b/tests/test_isrTaskLSST.py
@@ -1382,9 +1382,9 @@ class IsrTaskLSSTTestCase(lsst.utils.tests.TestCase):
         noDataExp = (result.exposure.mask.array & result.exposure.mask.getPlaneBitMask("NO_DATA")) > 0
         np.testing.assert_array_equal(noDataExp, noDataFlat)
         np.testing.assert_array_equal(result.exposure.image.array[noDataExp], 0.0)
-        np.testing.assert_array_equal(result.exposure.variance.array[noDataExp], 0.0)
+        np.testing.assert_array_equal(result.exposure.variance.array[noDataExp], isr_config.noDataVariance)
         self.assertFalse(np.any(~np.isfinite(result.exposure.image.array)))
-        self.assertFalse(np.any(~np.isfinite(result.exposure.variance.array)))
+        self.assertFalse(np.any(~np.isfinite(result.exposure.variance.array[~noDataExp])))
 
     def test_isrFloodedSaturatedE2V(self):
         """Test ISR when the amps are completely saturated.


### PR DESCRIPTION
This prevents possible detections in the fully vignetted corners.

This also makes sure that NO_DATA pixels aren't also marked BAD, preventing accidental interpolation and filling of pixels that should not have data.